### PR TITLE
removed usage of easydict in runner.py to fix problem with override b…

### DIFF
--- a/libs/feature/player/server/src/lib/sandboxes/python.ts
+++ b/libs/feature/player/server/src/lib/sandboxes/python.ts
@@ -3,22 +3,26 @@ import * as fs from 'fs';
 import * as tar from 'tar-stream';
 import * as zlib from 'zlib';
 
-import { HttpService } from "@nestjs/axios";
-import { Injectable } from "@nestjs/common";
-import { firstValueFrom } from "rxjs";
+import { HttpService } from '@nestjs/axios';
+import { Injectable } from '@nestjs/common';
+import { firstValueFrom } from 'rxjs';
 
 import { ConfigService } from '@nestjs/config';
 import { Configuration } from '@platon/core/server';
-import { withTempFile } from "@platon/shared/server";
-import { RegisterSandbox, Sandbox, SandboxError, SandboxInput, SandboxOutput } from "./sandbox";
-
+import { withTempFile } from '@platon/shared/server';
+import {
+  RegisterSandbox,
+  Sandbox,
+  SandboxError,
+  SandboxInput,
+  SandboxOutput,
+} from './sandbox';
 
 const runner = `
 #!/usr/bin/env python3
 # coding: utf-8
 
 import uuid, sys, json, jsonpickle, types
-from easydict import EasyDict as Object
 
 class StopExec(Exception):
     pass
@@ -32,7 +36,7 @@ def with_try_clause(code, excpt):
     )
 
 def component(selector):
-    return Object({ 'selector': selector, 'cid': str(uuid.uuid4()) })
+    return { 'selector': selector, 'cid': str(uuid.uuid4()) }
 
 def jsonify(d):
     keys = ['Object', 'component', 'StopExec']
@@ -46,13 +50,12 @@ if __name__ == "__main__":
       script = f.read()
 
     with open("variables.json", "r") as f:
-      variables = Object(json.load(f))
+      variables = json.load(f)
 
     glob = {}
 
-    variables.Object = Object
-    variables.component = component
-    variables.StopExec = StopExec
+    variables['component'] = component
+    variables['StopExec'] = StopExec
 
     exec(with_try_clause(script, StopExec), variables)
     exec("", glob)
@@ -64,7 +67,7 @@ if __name__ == "__main__":
     print(jsonpickle.encode(jsonify(variables), unpicklable=False))
 
     sys.exit(0)
-`
+`;
 
 interface ExecutionResult {
   status: number;
@@ -75,69 +78,76 @@ interface ExecutionResult {
     time: number;
   }[];
   total_time: number;
-  result: number,
-  environment: string,
+  result: number;
+  environment: string;
   expire: string;
 }
-
 
 @Injectable()
 @RegisterSandbox()
 export class PythonSandbox implements Sandbox {
   constructor(
     private readonly http: HttpService,
-    private readonly config: ConfigService<Configuration>,
-  ) { }
+    private readonly config: ConfigService<Configuration>
+  ) {}
 
   supports(input: SandboxInput): boolean {
     const { sandbox } = input.variables;
     return sandbox === 'python';
   }
 
-  async run(input: SandboxInput, script: string, timeout: number): Promise<SandboxOutput> {
+  async run(
+    input: SandboxInput,
+    script: string,
+    timeout: number
+  ): Promise<SandboxOutput> {
     try {
-      const response = await withTempFile(async (path) => {
-        await this.withEnvFiles(script, input, path);
+      const response = await withTempFile(
+        async (path) => {
+          await this.withEnvFiles(script, input, path);
 
-        const data = new FormData();
+          const data = new FormData();
 
-        data.append('config', JSON.stringify({
-          save: true,
-          commands: ["python3 runner.py"],
-          ...(input.envid ? { 'environment': input.envid } : {})
-        }));
+          data.append(
+            'config',
+            JSON.stringify({
+              save: true,
+              commands: ['python3 runner.py'],
+              ...(input.envid ? { environment: input.envid } : {}),
+            })
+          );
 
-        data.append(
-          'environment',
-          await fs.promises.readFile(path),
-          { filename: 'environment' }
-        );
+          data.append('environment', await fs.promises.readFile(path), {
+            filename: 'environment',
+          });
 
-        let url = this.config.get('sandbox.url', { infer: true }) as string;
-        if (!url.endsWith('/')) {
-          url += '/';
-        }
+          let url = this.config.get('sandbox.url', { infer: true }) as string;
+          if (!url.endsWith('/')) {
+            url += '/';
+          }
 
-        const result = await firstValueFrom(
-          this.http.post<ExecutionResult>(`${url}execute/`, data, {
-            headers: { 'Content-Type': 'multipart/form-data' },
-            timeout,
-          })
-        );
-        return result.data;
-      }, { prefix: 'envs', suffix: '.tgz', cleanup: false })
+          const result = await firstValueFrom(
+            this.http.post<ExecutionResult>(`${url}execute/`, data, {
+              headers: { 'Content-Type': 'multipart/form-data' },
+              timeout,
+            })
+          );
+          return result.data;
+        },
+        { prefix: 'envs', suffix: '.tgz', cleanup: false }
+      );
 
       if (response.status === -2) {
         throw SandboxError.timeoutError(timeout);
       }
 
       if (response.status !== 0) {
-        throw SandboxError.unknownError(response.execution[0].stderr)
+        throw SandboxError.unknownError(response.execution[0].stderr);
       }
 
       return Promise.resolve({
         envid: response.environment,
-        variables: JSON.parse(response.execution[0].stdout)
+        variables: JSON.parse(response.execution[0].stdout),
       });
     } catch (error) {
       if (error instanceof SandboxError) {
@@ -147,7 +157,11 @@ export class PythonSandbox implements Sandbox {
     }
   }
 
-  private async withEnvFiles(script: string, input: SandboxInput, path: string) {
+  private async withEnvFiles(
+    script: string,
+    input: SandboxInput,
+    path: string
+  ) {
     const pack = tar.pack();
 
     pack.entry({ name: 'script.py' }, script);
@@ -155,7 +169,9 @@ export class PythonSandbox implements Sandbox {
 
     if (!input.envid) {
       pack.entry({ name: 'runner.py' }, runner);
-      input.files?.forEach(file => pack.entry({ name: file.path }, file.content));
+      input.files?.forEach((file) =>
+        pack.entry({ name: file.path }, file.content)
+      );
     }
 
     pack.finalize();


### PR DESCRIPTION
Removed the usage of easydict in the runner.py for the python sandbox to get rid of a bug which occurred when attributes with the same name as a built in dictionary method were defines (for example, "items").

It broke the usage of the Python sandbox whenever this happened.