### PR TITLE
fix parsing of boolean values

### DIFF
--- a/libs/feature/compiler/src/lib/pl.jison
+++ b/libs/feature/compiler/src/lib/pl.jison
@@ -301,9 +301,9 @@ value
     | IDENTIFIER
       { $$ = new PLReference($1, yylineno + 1); }
     | BOOLEAN
-      { $$ = new PLBoolean(Boolean($1.toLowerCase()), yylineno + 1); }
+      { $$ = new PLBoolean($1.toLowerCase() === "true", yylineno + 1); }
     | STRING
-      { $$ = new PLString($1.slice(1, -1), yylineno + 1); }
+      { $$ = new PLString($1.slice(1, -1), yylineno + 1);}
     | EXTENDS PATH
       { $$ = new PLDict($2, yylineno + 1); }
     | COPYURL PATH

--- a/libs/feature/compiler/src/lib/pl.parser.ts
+++ b/libs/feature/compiler/src/lib/pl.parser.ts
@@ -3,22 +3,23 @@
  * Returns a Parser implementing JisonParserApi and a Lexer implementing JisonLexerApi.
  */
 
-
-import { v4 as uuidv4 } from 'uuid'
+import { v4 as uuidv4 } from 'uuid';
 
 // VALUES
 
 interface PLValue {
-  readonly value: string | number | boolean | PLValue[] | {key: string, value: PLValue}[];
+  readonly value:
+    | string
+    | number
+    | boolean
+    | PLValue[]
+    | { key: string; value: PLValue }[];
   readonly lineno: number;
   toJSON(visitor: PLVisitor): any | Promise<any>;
 }
 
 export class PLArray implements PLValue {
-  constructor(
-    readonly value: PLValue[],
-    readonly lineno: number,
-  ) {}
+  constructor(readonly value: PLValue[], readonly lineno: number) {}
   async toJSON(visitor: PLVisitor) {
     const result: any[] = [];
     // do not use promise.all to allow cache file operations (@copyurl, @copycontent...)
@@ -31,8 +32,8 @@ export class PLArray implements PLValue {
 
 export class PLObject implements PLValue {
   constructor(
-    readonly value: {key: string, value: PLValue}[],
-    readonly lineno: number,
+    readonly value: { key: string; value: PLValue }[],
+    readonly lineno: number
   ) {}
   async toJSON(visitor: PLVisitor) {
     // do not use promise.all to allow cache file operations (@copyurl, @copycontent...)
@@ -47,71 +48,61 @@ export class PLObject implements PLValue {
 }
 
 export class PLString implements PLValue {
-  constructor(
-    readonly value: string,
-    readonly lineno: number,
-  ) {}
+  constructor(readonly value: string, readonly lineno: number) {}
 
-  toJSON() { return this.value.trim(); }
+  toJSON() {
+    return this.value.trim();
+  }
 }
 
 export class PLNumber implements PLValue {
-  constructor(
-    readonly value: number,
-    readonly lineno: number,
-  ) {}
-  toJSON() { return this.value; }
+  constructor(readonly value: number, readonly lineno: number) {}
+  toJSON() {
+    return this.value;
+  }
 }
 
 export class PLBoolean implements PLValue {
-  constructor(
-    readonly value: boolean,
-    readonly lineno: number,
-  ) {}
-  toJSON() { return this.value; }
+  constructor(readonly value: boolean, readonly lineno: number) {}
+  toJSON() {
+    return this.value;
+  }
 }
 
 export class PLComponent implements PLValue {
-  constructor(
-    readonly value: string,
-    readonly lineno: number,
-  ) {}
-  toJSON() { return { 'cid': uuidv4(), selector: this.value }; }
+  constructor(readonly value: string, readonly lineno: number) {}
+  toJSON() {
+    return { cid: uuidv4(), selector: this.value };
+  }
 }
 
 export class PLDict implements PLValue {
-  constructor(
-    readonly value: string,
-    readonly lineno: number,
-  ) {}
+  constructor(readonly value: string, readonly lineno: number) {}
   async toJSON(visitor: PLVisitor) {
     const source = await visitor.visitExtends(this, false);
-    return source.variables
+    return source.variables;
   }
 }
 
 export class PLFileURL implements PLValue {
-  constructor(
-    readonly value: string,
-    readonly lineno: number,
-  ) {}
-  toJSON(visitor: PLVisitor) { return visitor.visitCopyUrl(this); }
+  constructor(readonly value: string, readonly lineno: number) {}
+  toJSON(visitor: PLVisitor) {
+    return visitor.visitCopyUrl(this);
+  }
 }
 
 export class PLReference implements PLValue {
-  constructor(
-    readonly value: string,
-    readonly lineno: number,
-  ) {}
-  toJSON(visitor: PLVisitor) { return visitor.visitReference(this); }
+  constructor(readonly value: string, readonly lineno: number) {}
+  toJSON(visitor: PLVisitor) {
+    return visitor.visitReference(this);
+  }
 }
 
 export class PLFileContent implements PLValue {
-  constructor(
-    readonly value: string,
-    readonly lineno: number,
-  ) {}
-  toJSON(visitor: PLVisitor) { return visitor.visitCopyContent(this); }
+  constructor(readonly value: string, readonly lineno: number) {}
+  toJSON(visitor: PLVisitor) {
+    return visitor.visitCopyContent(this);
+  }
 }
 
 // NODES
@@ -121,20 +112,14 @@ export interface PLNode {
 }
 
 export class ExtendsNode implements PLNode {
-  constructor(
-    readonly path: string,
-    readonly lineno: number
-  ) {}
+  constructor(readonly path: string, readonly lineno: number) {}
   async accept(visitor: PLVisitor): Promise<void> {
     await visitor.visitExtends(this, true);
   }
 }
 
 export class CommentNode implements PLNode {
-  constructor(
-    readonly value: string,
-    readonly lineno: number
-  ) {}
+  constructor(readonly value: string, readonly lineno: number) {}
   accept(visitor: PLVisitor): Promise<void> {
     return visitor.visitComment(this);
   }
@@ -144,7 +129,7 @@ export class IncludeNode implements PLNode {
   constructor(
     readonly path: string,
     readonly alias: string,
-    readonly lineno: number,
+    readonly lineno: number
   ) {}
   accept(visitor: PLVisitor): Promise<void> {
     return visitor.visitInclude(this);
@@ -162,9 +147,7 @@ export class AssignmentNode implements PLNode {
   }
 }
 
-
 // AST
-
 
 export interface PLDependency {
   alias?: string;
@@ -178,14 +161,14 @@ export interface PLSourceFile {
   version: string;
   abspath: string;
   errors: {
-    lineno: number,
-    abspath: string
-    description: string
+    lineno: number;
+    abspath: string;
+    description: string;
   }[];
   warnings: {
-    lineno: number,
-    abspath: string
-    description: string
+    lineno: number;
+    abspath: string;
+    description: string;
   }[];
   variables: Record<string, unknown>;
   dependencies: PLDependency[];
@@ -195,7 +178,10 @@ export interface PLSourceFile {
 
 export interface PLVisitor {
   visit(nodes: PLNode[]): Promise<PLSourceFile>;
-  visitExtends(node: ExtendsNode | PLDict, merge: boolean): Promise<PLSourceFile>;
+  visitExtends(
+    node: ExtendsNode | PLDict,
+    merge: boolean
+  ): Promise<PLSourceFile>;
   visitInclude(node: IncludeNode): Promise<void>;
   visitComment(node: CommentNode): Promise<void>;
   visitAssignment(node: AssignmentNode): Promise<void>;
@@ -204,200 +190,578 @@ export interface PLVisitor {
   visitCopyContent(node: PLFileContent): Promise<string>;
 }
 
-
-
-import { JisonParser, JisonParserApi, StateType, SymbolsType, TerminalsType, ProductionsType, o } from '@ts-jison/parser';const $V0=[1,8],$V1=[1,9],$V2=[1,11],$V3=[1,10],$V4=[5,8,12,19,34],$V5=[1,24],$V6=[1,23],$V7=[1,25],$V8=[1,26],$V9=[1,27],$Va=[1,28],$Vb=[1,29],$Vc=[1,30],$Vd=[1,31],$Ve=[1,32],$Vf=[1,36],$Vg=[13,31],$Vh=[5,8,12,19,26,29,32,34],$Vi=[1,49],$Vj=[26,32],$Vk=[29,32];
+import {
+  JisonParser,
+  JisonParserApi,
+  StateType,
+  SymbolsType,
+  TerminalsType,
+  ProductionsType,
+  o,
+} from '@ts-jison/parser';
+const $V0 = [1, 8],
+  $V1 = [1, 9],
+  $V2 = [1, 11],
+  $V3 = [1, 10],
+  $V4 = [5, 8, 12, 19, 34],
+  $V5 = [1, 24],
+  $V6 = [1, 23],
+  $V7 = [1, 25],
+  $V8 = [1, 26],
+  $V9 = [1, 27],
+  $Va = [1, 28],
+  $Vb = [1, 29],
+  $Vc = [1, 30],
+  $Vd = [1, 31],
+  $Ve = [1, 32],
+  $Vf = [1, 36],
+  $Vg = [13, 31],
+  $Vh = [5, 8, 12, 19, 26, 29, 32, 34],
+  $Vi = [1, 49],
+  $Vj = [26, 32],
+  $Vk = [29, 32];
 
 export class PLParser extends JisonParser implements JisonParserApi {
-    $?: any;
+  $?: any;
 
-    constructor (yy = {}, lexer = new PLLexer(yy)) {
-      super(yy, lexer);
-    }
+  constructor(yy = {}, lexer = new plLexer(yy)) {
+    super(yy, lexer);
+  }
 
-    symbols_: SymbolsType = {"error":2,"program":3,"statements":4,"EOF":5,"statement":6,"comment":7,"COMMENT":8,"assignment_statement":9,"include_statement":10,"extends_statement":11,"IDENTIFIER":12,"EQUALS":13,"value_multi":14,"value":15,"NUMBER":16,"BOOLEAN":17,"STRING":18,"EXTENDS":19,"PATH":20,"COPYURL":21,"COPYCONTENT":22,"COLON":23,"SELECTOR":24,"LBRACKET":25,"RBRACKET":26,"elements":27,"LBRACE":28,"RBRACE":29,"pairs":30,"ANY":31,"COMMA":32,"pair":33,"INCLUDE":34,"AS":35,"$accept":0,"$end":1};
-    terminals_: TerminalsType = {2:"error",5:"EOF",8:"COMMENT",12:"IDENTIFIER",13:"EQUALS",16:"NUMBER",17:"BOOLEAN",18:"STRING",19:"EXTENDS",20:"PATH",21:"COPYURL",22:"COPYCONTENT",23:"COLON",24:"SELECTOR",25:"LBRACKET",26:"RBRACKET",28:"LBRACE",29:"RBRACE",31:"ANY",32:"COMMA",34:"INCLUDE",35:"AS"};
-    productions_: ProductionsType = [0,[3,2],[4,1],[4,1],[4,2],[4,2],[7,1],[6,1],[6,1],[6,1],[9,4],[9,3],[9,4],[9,3],[15,2],[15,1],[15,1],[15,1],[15,1],[15,2],[15,2],[15,2],[15,2],[15,2],[15,3],[15,2],[15,3],[14,2],[14,1],[27,1],[27,3],[30,1],[30,3],[33,3],[10,2],[10,4],[11,2]];
-    table: Array<StateType> = [{3:1,4:2,6:3,7:4,8:$V0,9:5,10:6,11:7,12:$V1,19:$V2,34:$V3},{1:[3]},{5:[1,12],6:14,7:13,8:$V0,9:5,10:6,11:7,12:$V1,19:$V2,34:$V3},o($V4,[2,2]),o($V4,[2,3]),o($V4,[2,7]),o($V4,[2,8]),o($V4,[2,9]),o($V4,[2,6]),{13:[1,15]},{20:[1,16]},{20:[1,17]},{1:[2,1]},o($V4,[2,4]),o($V4,[2,5]),{8:[1,18],12:$V5,13:[1,19],14:20,15:21,16:$V6,17:$V7,18:$V8,19:$V9,21:$Va,22:$Vb,23:$Vc,25:$Vd,28:$Ve,31:[1,22]},o($V4,[2,34],{35:[1,33]}),o($V4,[2,36]),{8:$Vf,12:$V5,13:[1,34],15:35,16:$V6,17:$V7,18:$V8,19:$V9,21:$Va,22:$Vb,23:$Vc,25:$Vd,28:$Ve},o($V4,[2,11]),{13:[1,37],31:[1,38]},o($V4,[2,13]),o($Vg,[2,28]),o($Vh,[2,15]),o($Vh,[2,16]),o($Vh,[2,17]),o($Vh,[2,18]),{20:[1,39]},{20:[1,40]},{20:[1,41]},{24:[1,42]},{8:$Vf,12:$V5,15:45,16:$V6,17:$V7,18:$V8,19:$V9,21:$Va,22:$Vb,23:$Vc,25:$Vd,26:[1,43],27:44,28:$Ve},{12:$Vi,29:[1,46],30:47,33:48},{20:[1,50]},o($V4,[2,10]),o($Vh,[2,14]),{8:$Vf,12:$V5,15:35,16:$V6,17:$V7,18:$V8,19:$V9,21:$Va,22:$Vb,23:$Vc,25:$Vd,28:$Ve},o($V4,[2,12]),o($Vg,[2,27]),o($Vh,[2,19]),o($Vh,[2,20]),o($Vh,[2,21]),o($Vh,[2,22]),o($Vh,[2,23]),{26:[1,51],32:[1,52]},o($Vj,[2,29]),o($Vh,[2,25]),{29:[1,53],32:[1,54]},o($Vk,[2,31]),{23:[1,55]},o($V4,[2,35]),o($Vh,[2,24]),{8:$Vf,12:$V5,15:56,16:$V6,17:$V7,18:$V8,19:$V9,21:$Va,22:$Vb,23:$Vc,25:$Vd,28:$Ve},o($Vh,[2,26]),{12:$Vi,33:57},{8:$Vf,12:$V5,15:58,16:$V6,17:$V7,18:$V8,19:$V9,21:$Va,22:$Vb,23:$Vc,25:$Vd,28:$Ve},o($Vj,[2,30]),o($Vk,[2,32]),o($Vk,[2,33])];
-    defaultActions: {[key:number]: any} = {12:[2,1]};
+  symbols_: SymbolsType = {
+    error: 2,
+    program: 3,
+    statements: 4,
+    EOF: 5,
+    statement: 6,
+    comment: 7,
+    COMMENT: 8,
+    assignment_statement: 9,
+    include_statement: 10,
+    extends_statement: 11,
+    IDENTIFIER: 12,
+    EQUALS: 13,
+    value_multi: 14,
+    value: 15,
+    NUMBER: 16,
+    BOOLEAN: 17,
+    STRING: 18,
+    EXTENDS: 19,
+    PATH: 20,
+    COPYURL: 21,
+    COPYCONTENT: 22,
+    COLON: 23,
+    SELECTOR: 24,
+    LBRACKET: 25,
+    RBRACKET: 26,
+    elements: 27,
+    LBRACE: 28,
+    RBRACE: 29,
+    pairs: 30,
+    ANY: 31,
+    COMMA: 32,
+    pair: 33,
+    INCLUDE: 34,
+    AS: 35,
+    $accept: 0,
+    $end: 1,
+  };
+  terminals_: TerminalsType = {
+    2: 'error',
+    5: 'EOF',
+    8: 'COMMENT',
+    12: 'IDENTIFIER',
+    13: 'EQUALS',
+    16: 'NUMBER',
+    17: 'BOOLEAN',
+    18: 'STRING',
+    19: 'EXTENDS',
+    20: 'PATH',
+    21: 'COPYURL',
+    22: 'COPYCONTENT',
+    23: 'COLON',
+    24: 'SELECTOR',
+    25: 'LBRACKET',
+    26: 'RBRACKET',
+    28: 'LBRACE',
+    29: 'RBRACE',
+    31: 'ANY',
+    32: 'COMMA',
+    34: 'INCLUDE',
+    35: 'AS',
+  };
+  productions_: ProductionsType = [
+    0,
+    [3, 2],
+    [4, 1],
+    [4, 1],
+    [4, 2],
+    [4, 2],
+    [7, 1],
+    [6, 1],
+    [6, 1],
+    [6, 1],
+    [9, 4],
+    [9, 3],
+    [9, 4],
+    [9, 3],
+    [15, 2],
+    [15, 1],
+    [15, 1],
+    [15, 1],
+    [15, 1],
+    [15, 2],
+    [15, 2],
+    [15, 2],
+    [15, 2],
+    [15, 2],
+    [15, 3],
+    [15, 2],
+    [15, 3],
+    [14, 2],
+    [14, 1],
+    [27, 1],
+    [27, 3],
+    [30, 1],
+    [30, 3],
+    [33, 3],
+    [10, 2],
+    [10, 4],
+    [11, 2],
+  ];
+  table: Array<StateType> = [
+    {
+      3: 1,
+      4: 2,
+      6: 3,
+      7: 4,
+      8: $V0,
+      9: 5,
+      10: 6,
+      11: 7,
+      12: $V1,
+      19: $V2,
+      34: $V3,
+    },
+    { 1: [3] },
+    {
+      5: [1, 12],
+      6: 14,
+      7: 13,
+      8: $V0,
+      9: 5,
+      10: 6,
+      11: 7,
+      12: $V1,
+      19: $V2,
+      34: $V3,
+    },
+    o($V4, [2, 2]),
+    o($V4, [2, 3]),
+    o($V4, [2, 7]),
+    o($V4, [2, 8]),
+    o($V4, [2, 9]),
+    o($V4, [2, 6]),
+    { 13: [1, 15] },
+    { 20: [1, 16] },
+    { 20: [1, 17] },
+    { 1: [2, 1] },
+    o($V4, [2, 4]),
+    o($V4, [2, 5]),
+    {
+      8: [1, 18],
+      12: $V5,
+      13: [1, 19],
+      14: 20,
+      15: 21,
+      16: $V6,
+      17: $V7,
+      18: $V8,
+      19: $V9,
+      21: $Va,
+      22: $Vb,
+      23: $Vc,
+      25: $Vd,
+      28: $Ve,
+      31: [1, 22],
+    },
+    o($V4, [2, 34], { 35: [1, 33] }),
+    o($V4, [2, 36]),
+    {
+      8: $Vf,
+      12: $V5,
+      13: [1, 34],
+      15: 35,
+      16: $V6,
+      17: $V7,
+      18: $V8,
+      19: $V9,
+      21: $Va,
+      22: $Vb,
+      23: $Vc,
+      25: $Vd,
+      28: $Ve,
+    },
+    o($V4, [2, 11]),
+    { 13: [1, 37], 31: [1, 38] },
+    o($V4, [2, 13]),
+    o($Vg, [2, 28]),
+    o($Vh, [2, 15]),
+    o($Vh, [2, 16]),
+    o($Vh, [2, 17]),
+    o($Vh, [2, 18]),
+    { 20: [1, 39] },
+    { 20: [1, 40] },
+    { 20: [1, 41] },
+    { 24: [1, 42] },
+    {
+      8: $Vf,
+      12: $V5,
+      15: 45,
+      16: $V6,
+      17: $V7,
+      18: $V8,
+      19: $V9,
+      21: $Va,
+      22: $Vb,
+      23: $Vc,
+      25: $Vd,
+      26: [1, 43],
+      27: 44,
+      28: $Ve,
+    },
+    { 12: $Vi, 29: [1, 46], 30: 47, 33: 48 },
+    { 20: [1, 50] },
+    o($V4, [2, 10]),
+    o($Vh, [2, 14]),
+    {
+      8: $Vf,
+      12: $V5,
+      15: 35,
+      16: $V6,
+      17: $V7,
+      18: $V8,
+      19: $V9,
+      21: $Va,
+      22: $Vb,
+      23: $Vc,
+      25: $Vd,
+      28: $Ve,
+    },
+    o($V4, [2, 12]),
+    o($Vg, [2, 27]),
+    o($Vh, [2, 19]),
+    o($Vh, [2, 20]),
+    o($Vh, [2, 21]),
+    o($Vh, [2, 22]),
+    o($Vh, [2, 23]),
+    { 26: [1, 51], 32: [1, 52] },
+    o($Vj, [2, 29]),
+    o($Vh, [2, 25]),
+    { 29: [1, 53], 32: [1, 54] },
+    o($Vk, [2, 31]),
+    { 23: [1, 55] },
+    o($V4, [2, 35]),
+    o($Vh, [2, 24]),
+    {
+      8: $Vf,
+      12: $V5,
+      15: 56,
+      16: $V6,
+      17: $V7,
+      18: $V8,
+      19: $V9,
+      21: $Va,
+      22: $Vb,
+      23: $Vc,
+      25: $Vd,
+      28: $Ve,
+    },
+    o($Vh, [2, 26]),
+    { 12: $Vi, 33: 57 },
+    {
+      8: $Vf,
+      12: $V5,
+      15: 58,
+      16: $V6,
+      17: $V7,
+      18: $V8,
+      19: $V9,
+      21: $Va,
+      22: $Vb,
+      23: $Vc,
+      25: $Vd,
+      28: $Ve,
+    },
+    o($Vj, [2, 30]),
+    o($Vk, [2, 32]),
+    o($Vk, [2, 33]),
+  ];
+  defaultActions: { [key: number]: any } = { 12: [2, 1] };
 
-    performAction (yytext:string, yyleng:number, yylineno:number, yy:any, yystate:number /* action[1] */, $$:any /* vstack */, _$:any /* lstack */): any {
-/* this == yyval */
-          var $0 = $$.length - 1;
-        switch (yystate) {
-case 1:
- return $$[$0-1] 
-break;
-case 2: case 29: case 31:
- this.$ = [$$[$0]]; 
-break;
-case 3:
- this.$ = [$$[$0]] 
-break;
-case 4:
- this.$ = $$[$0-1].concat($$[$0]) 
-break;
-case 5:
- this.$ = $$[$0-1].concat($$[$0]); 
-break;
-case 6:
- this.$ = new CommentNode($$[$0], yylineno + 1); 
-break;
-case 7: case 8: case 9: case 14:
- this.$ = $$[$0]; 
-break;
-case 10:
- this.$ = new AssignmentNode($$[$0-3], new PLString('', yylineno + 1), yylineno + 1); 
-break;
-case 11:
- this.$ = new AssignmentNode($$[$0-2], new PLString('', yylineno + 1), yylineno + 1); 
-break;
-case 12:
- this.$ = new AssignmentNode($$[$0-3], new PLString($$[$0-1], yylineno + 1), yylineno + 1); 
-break;
-case 13:
- this.$ = new AssignmentNode($$[$0-2], $$[$0], yylineno + 1); 
-break;
-case 15:
- this.$ = new PLNumber(Number($$[$0].replace(/_/g, '')), yylineno + 1); 
-break;
-case 16:
- this.$ = new PLReference($$[$0], yylineno + 1); 
-break;
-case 17:
- this.$ = new PLBoolean(Boolean($$[$0].toLowerCase()), yylineno + 1); 
-break;
-case 18:
- this.$ = new PLString($$[$0].slice(1, -1), yylineno + 1); 
-break;
-case 19:
- this.$ = new PLDict($$[$0], yylineno + 1); 
-break;
-case 20:
- this.$ = new PLFileURL($$[$0], yylineno + 1); 
-break;
-case 21:
- this.$ = new PLFileContent($$[$0], yylineno + 1); 
-break;
-case 22:
- this.$ = new PLComponent($$[$0], yylineno + 1); 
-break;
-case 23:
- this.$ = new PLArray([], yylineno + 1); 
-break;
-case 24:
- this.$ = new PLArray($$[$0-1], yylineno + 1); 
-break;
-case 25:
- this.$ = new PLObject([], yylineno + 1); 
-break;
-case 26:
- this.$ = new PLObject($$[$0-1], yylineno + 1); 
-break;
-case 27:
+  performAction(
+    yytext: string,
+    yyleng: number,
+    yylineno: number,
+    yy: any,
+    yystate: number /* action[1] */,
+    $$: any /* vstack */,
+    _$: any /* lstack */
+  ): any {
+    /* this == yyval */
+    var $0 = $$.length - 1;
+    switch (yystate) {
+      case 1:
+        return $$[$0 - 1];
+        break;
+      case 2:
+      case 29:
+      case 31:
+        this.$ = [$$[$0]];
+        break;
+      case 3:
+        this.$ = [$$[$0]];
+        break;
+      case 4:
+        this.$ = $$[$0 - 1].concat($$[$0]);
+        break;
+      case 5:
+        this.$ = $$[$0 - 1].concat($$[$0]);
+        break;
+      case 6:
+        this.$ = new CommentNode($$[$0], yylineno + 1);
+        break;
+      case 7:
+      case 8:
+      case 9:
+      case 14:
+        this.$ = $$[$0];
+        break;
+      case 10:
+        this.$ = new AssignmentNode(
+          $$[$0 - 3],
+          new PLString('', yylineno + 1),
+          yylineno + 1
+        );
+        break;
+      case 11:
+        this.$ = new AssignmentNode(
+          $$[$0 - 2],
+          new PLString('', yylineno + 1),
+          yylineno + 1
+        );
+        break;
+      case 12:
+        this.$ = new AssignmentNode(
+          $$[$0 - 3],
+          new PLString($$[$0 - 1], yylineno + 1),
+          yylineno + 1
+        );
+        break;
+      case 13:
+        this.$ = new AssignmentNode($$[$0 - 2], $$[$0], yylineno + 1);
+        break;
+      case 15:
+        this.$ = new PLNumber(Number($$[$0].replace(/_/g, '')), yylineno + 1);
+        break;
+      case 16:
+        this.$ = new PLReference($$[$0], yylineno + 1);
+        break;
+      case 17:
+        this.$ = new PLBoolean($$[$0].toLowerCase() === 'true', yylineno + 1);
+        break;
+      case 18:
+        this.$ = new PLString($$[$0].slice(1, -1), yylineno + 1);
+        break;
+      case 19:
+        this.$ = new PLDict($$[$0], yylineno + 1);
+        break;
+      case 20:
+        this.$ = new PLFileURL($$[$0], yylineno + 1);
+        break;
+      case 21:
+        this.$ = new PLFileContent($$[$0], yylineno + 1);
+        break;
+      case 22:
+        this.$ = new PLComponent($$[$0], yylineno + 1);
+        break;
+      case 23:
+        this.$ = new PLArray([], yylineno + 1);
+        break;
+      case 24:
+        this.$ = new PLArray($$[$0 - 1], yylineno + 1);
+        break;
+      case 25:
+        this.$ = new PLObject([], yylineno + 1);
+        break;
+      case 26:
+        this.$ = new PLObject($$[$0 - 1], yylineno + 1);
+        break;
+      case 27:
+        this.$ = $$[$0 - 1] + $$[$0];
 
-        this.$ = $$[$0-1] + $$[$0];
-      
-break;
-case 28:
-
+        break;
+      case 28:
         if ($$[$0].trim().startsWith('#!lang=')) {
           this.$ = '';
         } else {
           this.$ = $$[$0];
         }
-    
-break;
-case 30: case 32:
- this.$ = $$[$0-2].concat($$[$0]); 
-break;
-case 33:
- this.$ = { key: $$[$0-2], value: $$[$0] }; 
-break;
-case 34:
- this.$ = new IncludeNode($$[$0], '', yylineno + 1); 
-break;
-case 35:
- this.$ = new IncludeNode($$[$0-2], $$[$0], yylineno + 1); 
-break;
-case 36:
- this.$ = new ExtendsNode($$[$0], yylineno + 1); 
-break;
-        }
-    }
-}
 
+        break;
+      case 30:
+      case 32:
+        this.$ = $$[$0 - 2].concat($$[$0]);
+        break;
+      case 33:
+        this.$ = { key: $$[$0 - 2], value: $$[$0] };
+        break;
+      case 34:
+        this.$ = new IncludeNode($$[$0], '', yylineno + 1);
+        break;
+      case 35:
+        this.$ = new IncludeNode($$[$0 - 2], $$[$0], yylineno + 1);
+        break;
+      case 36:
+        this.$ = new ExtendsNode($$[$0], yylineno + 1);
+        break;
+    }
+  }
+}
 
 /* generated by ts-jison-lex 0.3.0 */
 import { JisonLexer, JisonLexerApi } from '@ts-jison/lexer';
-export class PLLexer extends JisonLexer implements JisonLexerApi {
-    options: any = {"moduleName":"PL"};
-    constructor (yy = {}) {
-        super(yy);
-    }
+export class plLexer extends JisonLexer implements JisonLexerApi {
+  options: any = { moduleName: 'pl' };
+  constructor(yy = {}) {
+    super(yy);
+  }
 
-    rules: RegExp[] = [/^(?:\s+)/,/^(?:#.*)/,/^(?:\/\/.*)/,/^(?:\/\*([^*]|\*[^\/])*\*\/)/,/^(?:==)/,/^(?:=)/,/^(?:@copycontent\b)/,/^(?:@copyurl\b)/,/^(?:@include\b)/,/^(?:@extends\b)/,/^(?:as\b)/,/^(?:\/[^\s\n\,]+)/,/^(?:[+-]?\d+((_|\.)+\d+)*)/,/^(?:[,])/,/^(?:[:])/,/^(?:[\{])/,/^(?:[\}])/,/^(?:[\[])/,/^(?:[\]])/,/^(?:true|false|True|False\b)/,/^(?:wc-[a-zA-Z0-9_-]+)/,/^(?:[a-zA-Z_](\.?[a-zA-Z0-9_])*)/,/^(?:"([^\\\"]|\\.)*")/,/^(?:$)/,/^(?:[^\n]*\n)/];
-    conditions: any = {"MULTI":{"rules":[23,24],"inclusive":true},"INITIAL":{"rules":[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23],"inclusive":true}}
-    performAction (yy:any,yy_:any,$avoiding_name_collisions:any,YY_START:any): any {
-          var YYSTATE=YY_START;
-        switch($avoiding_name_collisions) {
-    case 0:/* ignore whitespace */
-      break;
-    case 1:return 8
-      break;
-    case 2:return 8
-      break;
-    case 3:return 8
-      break;
-    case 4: this.begin('MULTI'); return 13; 
-      break;
-    case 5:return 13
-      break;
-    case 6:return 22
-      break;
-    case 7:return 21
-      break;
-    case 8:return 34
-      break;
-    case 9:return 19
-      break;
-    case 10:return 35
-      break;
-    case 11:return 20 // COMMA AT THE END ALLOW TO INCLUDES PATH INSIDE ARRAY
-      break;
-    case 12:return 16
-      break;
-    case 13:return 32
-      break;
-    case 14:return 23
-      break;
-    case 15:return 28
-      break;
-    case 16:return 29
-      break;
-    case 17:return 25
-      break;
-    case 18:return 26
-      break;
-    case 19:return 17
-      break;
-    case 20:return 24
-      break;
-    case 21:return 12
-      break;
-    case 22:return 18
-      break;
-    case 23:return 5
-      break;
-    case 24:
-                          if (yy_.yytext.trim() === '==') {
-                            this.popState();
-                            return 13;
-                          }
-                          return 31
-                         
-      break;
+  rules: RegExp[] = [
+    /^(?:\s+)/,
+    /^(?:#.*)/,
+    /^(?:\/\/.*)/,
+    /^(?:\/\*([^*]|\*[^\/])*\*\/)/,
+    /^(?:==)/,
+    /^(?:=)/,
+    /^(?:@copycontent\b)/,
+    /^(?:@copyurl\b)/,
+    /^(?:@include\b)/,
+    /^(?:@extends\b)/,
+    /^(?:as\b)/,
+    /^(?:\/[^\s\n\,]+)/,
+    /^(?:[+-]?\d+((_|\.)+\d+)*)/,
+    /^(?:[,])/,
+    /^(?:[:])/,
+    /^(?:[\{])/,
+    /^(?:[\}])/,
+    /^(?:[\[])/,
+    /^(?:[\]])/,
+    /^(?:true|false|True|False\b)/,
+    /^(?:wc-[a-zA-Z0-9_-]+)/,
+    /^(?:[a-zA-Z_](\.?[a-zA-Z0-9_])*)/,
+    /^(?:"([^\\\"]|\\.)*")/,
+    /^(?:$)/,
+    /^(?:[^\n]*\n)/,
+  ];
+  conditions: any = {
+    MULTI: { rules: [23, 24], inclusive: true },
+    INITIAL: {
+      rules: [
+        0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19,
+        20, 21, 22, 23,
+      ],
+      inclusive: true,
+    },
+  };
+  performAction(
+    yy: any,
+    yy_: any,
+    $avoiding_name_collisions: any,
+    YY_START: any
+  ): any {
+    var YYSTATE = YY_START;
+    switch ($avoiding_name_collisions) {
+      case 0 /* ignore whitespace */:
+        break;
+      case 1:
+        return 8;
+        break;
+      case 2:
+        return 8;
+        break;
+      case 3:
+        return 8;
+        break;
+      case 4:
+        this.begin('MULTI');
+        return 13;
+        break;
+      case 5:
+        return 13;
+        break;
+      case 6:
+        return 22;
+        break;
+      case 7:
+        return 21;
+        break;
+      case 8:
+        return 34;
+        break;
+      case 9:
+        return 19;
+        break;
+      case 10:
+        return 35;
+        break;
+      case 11:
+        return 20; // COMMA AT THE END ALLOW TO INCLUDES PATH INSIDE ARRAY
+        break;
+      case 12:
+        return 16;
+        break;
+      case 13:
+        return 32;
+        break;
+      case 14:
+        return 23;
+        break;
+      case 15:
+        return 28;
+        break;
+      case 16:
+        return 29;
+        break;
+      case 17:
+        return 25;
+        break;
+      case 18:
+        return 26;
+        break;
+      case 19:
+        return 17;
+        break;
+      case 20:
+        return 24;
+        break;
+      case 21:
+        return 12;
+        break;
+      case 22:
+        return 18;
+        break;
+      case 23:
+        return 5;
+        break;
+      case 24:
+        if (yy_.yytext.trim() === '==') {
+          this.popState();
+          return 13;
         }
-    }
-}
+        return 31;
 
+        break;
+    }
+  }
+}


### PR DESCRIPTION
Fixed a bug with the parsing of boolean values in the PLParser. They were given the Boolean() constructor which simply evaluated to false if the string is empty, and true else, which meant for example that 'false' evaluated to true.