### PR TITLE
Dialog service delay implementation

### DIFF
--- a/libs/core/browser/src/lib/dialog/dialog.service.ts
+++ b/libs/core/browser/src/lib/dialog/dialog.service.ts
@@ -26,10 +26,10 @@ export class DialogService {
     private readonly nzNotificationService: NzNotificationService,
   ) { }
   
-  public static readonly DEFAULT_DIALOG_DURATION : number = 4.5;
+  public static readonly DEFAULT_DIALOG_DURATION : number = 4500;
 
   error(content: string, options: MessageOptions = { duration: DialogService.DEFAULT_DIALOG_DURATION }) {
-    if (options.duration == null) options.duration = DialogService.DEFAULT_DIALOG_DURATION;
+    if (options.duration == undefined) options.duration = DialogService.DEFAULT_DIALOG_DURATION;
     const ref = options?.notification
       ? this.nzNotificationService.error(options.notification.title, content, { nzDuration: options?.duration })
       : this.nzMessageService.error(content, { nzDuration: options?.duration });
@@ -40,7 +40,7 @@ export class DialogService {
   }
 
   info(content: string,  options: MessageOptions = { duration: DialogService.DEFAULT_DIALOG_DURATION }) {
-    if (options.duration == null) options.duration = DialogService.DEFAULT_DIALOG_DURATION;
+    if (options.duration == undefined) options.duration = DialogService.DEFAULT_DIALOG_DURATION;
     const ref = options?.notification
       ? this.nzNotificationService.info(options.notification.title, content, { nzDuration: options?.duration })
       : this.nzMessageService.info(content, { nzDuration: options?.duration });
@@ -51,7 +51,7 @@ export class DialogService {
   }
 
   success(content: string, options: MessageOptions = { duration: DialogService.DEFAULT_DIALOG_DURATION }) {
-    if (options.duration == null) options.duration = DialogService.DEFAULT_DIALOG_DURATION;
+    if (options.duration == undefined) options.duration = DialogService.DEFAULT_DIALOG_DURATION;
     const ref = options?.notification
       ? this.nzNotificationService.success(options.notification.title, content, { nzDuration: options?.duration })
       : this.nzMessageService.success(content, { nzDuration: options?.duration });
@@ -62,7 +62,7 @@ export class DialogService {
   }
 
   warning(content: string,  options: MessageOptions = { duration: DialogService.DEFAULT_DIALOG_DURATION }) {
-    if (options.duration == null) options.duration = DialogService.DEFAULT_DIALOG_DURATION;
+    if (options.duration == undefined) options.duration = DialogService.DEFAULT_DIALOG_DURATION;
     const ref = options?.notification
       ? this.nzNotificationService.warning(options.notification.title, content, { nzDuration: options?.duration })
       : this.nzMessageService.warning(content, { nzDuration: options?.duration });
@@ -73,7 +73,7 @@ export class DialogService {
   }
 
   notification(template: TemplateRef<object>, options: TemplateOptions = { duration: DialogService.DEFAULT_DIALOG_DURATION }) {
-    if (options.duration == null) options.duration = DialogService.DEFAULT_DIALOG_DURATION
+    if (options.duration == undefined) options.duration = DialogService.DEFAULT_DIALOG_DURATION
     const ref = this.nzNotificationService.template(template, {
       nzDuration: options?.duration,
       nzData: options?.data as object

--- a/libs/core/browser/src/lib/dialog/dialog.service.ts
+++ b/libs/core/browser/src/lib/dialog/dialog.service.ts
@@ -26,10 +26,10 @@ export class DialogService {
     private readonly nzNotificationService: NzNotificationService,
   ) { }
   
-  public static readonly DIALOG_DURATION : number = 4.5;
+  public static readonly DEFAULT_DIALOG_DURATION : number = 4.5;
 
-  error(content: string, options: MessageOptions = { duration: DialogService.DIALOG_DURATION }) {
-    if (options.duration == null) options.duration = DialogService.DIALOG_DURATION;
+  error(content: string, options: MessageOptions = { duration: DialogService.DEFAULT_DIALOG_DURATION }) {
+    if (options.duration == null) options.duration = DialogService.DEFAULT_DIALOG_DURATION;
     const ref = options?.notification
       ? this.nzNotificationService.error(options.notification.title, content, { nzDuration: options?.duration })
       : this.nzMessageService.error(content, { nzDuration: options?.duration });
@@ -39,8 +39,8 @@ export class DialogService {
     };
   }
 
-  info(content: string,  options: MessageOptions = { duration: DialogService.DIALOG_DURATION }) {
-    if (options.duration == null) options.duration = DialogService.DIALOG_DURATION;
+  info(content: string,  options: MessageOptions = { duration: DialogService.DEFAULT_DIALOG_DURATION }) {
+    if (options.duration == null) options.duration = DialogService.DEFAULT_DIALOG_DURATION;
     const ref = options?.notification
       ? this.nzNotificationService.info(options.notification.title, content, { nzDuration: options?.duration })
       : this.nzMessageService.info(content, { nzDuration: options?.duration });
@@ -50,8 +50,8 @@ export class DialogService {
     };
   }
 
-  success(content: string, options: MessageOptions = { duration: DialogService.DIALOG_DURATION }) {
-    if (options.duration == null) options.duration = DialogService.DIALOG_DURATION;
+  success(content: string, options: MessageOptions = { duration: DialogService.DEFAULT_DIALOG_DURATION }) {
+    if (options.duration == null) options.duration = DialogService.DEFAULT_DIALOG_DURATION;
     const ref = options?.notification
       ? this.nzNotificationService.success(options.notification.title, content, { nzDuration: options?.duration })
       : this.nzMessageService.success(content, { nzDuration: options?.duration });
@@ -61,8 +61,8 @@ export class DialogService {
     };
   }
 
-  warning(content: string,  options: MessageOptions = { duration: DialogService.DIALOG_DURATION }) {
-    if (options.duration == null) options.duration = DialogService.DIALOG_DURATION;
+  warning(content: string,  options: MessageOptions = { duration: DialogService.DEFAULT_DIALOG_DURATION }) {
+    if (options.duration == null) options.duration = DialogService.DEFAULT_DIALOG_DURATION;
     const ref = options?.notification
       ? this.nzNotificationService.warning(options.notification.title, content, { nzDuration: options?.duration })
       : this.nzMessageService.warning(content, { nzDuration: options?.duration });
@@ -72,8 +72,8 @@ export class DialogService {
     };
   }
 
-  notification(template: TemplateRef<object>, options: TemplateOptions = { duration: DialogService.DIALOG_DURATION }) {
-    if (options.duration == null) options.duration = DialogService.DIALOG_DURATION
+  notification(template: TemplateRef<object>, options: TemplateOptions = { duration: DialogService.DEFAULT_DIALOG_DURATION }) {
+    if (options.duration == null) options.duration = DialogService.DEFAULT_DIALOG_DURATION
     const ref = this.nzNotificationService.template(template, {
       nzDuration: options?.duration,
       nzData: options?.data as object

--- a/libs/core/browser/src/lib/dialog/dialog.service.ts
+++ b/libs/core/browser/src/lib/dialog/dialog.service.ts
@@ -25,7 +25,7 @@ export class DialogService {
     private readonly nzMessageService: NzMessageService,
     private readonly nzNotificationService: NzNotificationService,
   ) { }
-
+  
   public static readonly DIALOG_DURATION : number = 4.5;
 
   error(content: string, options: MessageOptions = { duration: DialogService.DIALOG_DURATION }) {

--- a/libs/core/browser/src/lib/dialog/dialog.service.ts
+++ b/libs/core/browser/src/lib/dialog/dialog.service.ts
@@ -26,8 +26,10 @@ export class DialogService {
     private readonly nzNotificationService: NzNotificationService,
   ) { }
 
+  public static readonly DIALOG_DURATION : number = 4.5;
 
-  error(content: string, options?: MessageOptions) {
+  error(content: string, options: MessageOptions = { duration: DialogService.DIALOG_DURATION }) {
+    if (options.duration == null) options.duration = DialogService.DIALOG_DURATION;
     const ref = options?.notification
       ? this.nzNotificationService.error(options.notification.title, content, { nzDuration: options?.duration })
       : this.nzMessageService.error(content, { nzDuration: options?.duration });
@@ -37,7 +39,8 @@ export class DialogService {
     };
   }
 
-  info(content: string, options?: MessageOptions) {
+  info(content: string,  options: MessageOptions = { duration: DialogService.DIALOG_DURATION }) {
+    if (options.duration == null) options.duration = DialogService.DIALOG_DURATION;
     const ref = options?.notification
       ? this.nzNotificationService.info(options.notification.title, content, { nzDuration: options?.duration })
       : this.nzMessageService.info(content, { nzDuration: options?.duration });
@@ -47,7 +50,8 @@ export class DialogService {
     };
   }
 
-  success(content: string, options?: MessageOptions) {
+  success(content: string, options: MessageOptions = { duration: DialogService.DIALOG_DURATION }) {
+    if (options.duration == null) options.duration = DialogService.DIALOG_DURATION;
     const ref = options?.notification
       ? this.nzNotificationService.success(options.notification.title, content, { nzDuration: options?.duration })
       : this.nzMessageService.success(content, { nzDuration: options?.duration });
@@ -57,7 +61,8 @@ export class DialogService {
     };
   }
 
-  warning(content: string, options?: MessageOptions) {
+  warning(content: string,  options: MessageOptions = { duration: DialogService.DIALOG_DURATION }) {
+    if (options.duration == null) options.duration = DialogService.DIALOG_DURATION;
     const ref = options?.notification
       ? this.nzNotificationService.warning(options.notification.title, content, { nzDuration: options?.duration })
       : this.nzMessageService.warning(content, { nzDuration: options?.duration });
@@ -67,7 +72,8 @@ export class DialogService {
     };
   }
 
-  notification(template: TemplateRef<object>, options?: TemplateOptions) {
+  notification(template: TemplateRef<object>, options: TemplateOptions = { duration: DialogService.DIALOG_DURATION }) {
+    if (options.duration == null) options.duration = DialogService.DIALOG_DURATION
     const ref = this.nzNotificationService.template(template, {
       nzDuration: options?.duration,
       nzData: options?.data as object


### PR DESCRIPTION
Je propose une modification qui consiste à intégrer un délai par défaut de disparition pour les alertes et messages fournies par le `DialogService` du projet

Ce fix vient du fait qu'on est rapidement spammé de notifications lors d'édition de ressource, point trouvé inconfortable par les utilisateurs actuels:

![image](https://github.com/cisstech/platon/assets/18609818/690952b3-ac4a-46b0-9f7d-f24244a42140)

À l'image de la lib NGZorro, j'ai établis le délai moyen à 4500ms 
> https://ng.ant.design/components/notification/en
