### PR TITLE
Feature/test unit integre e2e

### DIFF
--- a/apps/web/src/app/pages/editor/contributions/previews/pl-preview.contribution.ts
+++ b/apps/web/src/app/pages/editor/contributions/previews/pl-preview.contribution.ts
@@ -127,6 +127,20 @@ export class ResourceCommand implements ICommand {
   }
 }
 
+class BackToResourcesCommand implements ICommand {
+  readonly id = 'platon.contrib.toolbar.commands.back-to-resources'
+  readonly label = 'Retour aux ressources'
+  readonly icon = new CodIcon('arrow-left')
+
+  get enabled(): boolean {
+    return true
+  }
+
+  async execute(): Promise<void> {
+    window.location.href = '/resources'
+  }
+}
+
 @Injectable()
 export class Contribution implements IContribution {
   private readonly subscriptions: Subscription[] = []
@@ -160,6 +174,7 @@ export class Contribution implements IContribution {
 
     const previewFromToolbar = new ToolbarPreviewCommand(presenter, fileService, editorService)
     const resourceCommand = new ResourceCommand(presenter)
+    const backToResourcesCommand = new BackToResourcesCommand()
 
     commandService.register(previewFromToolbar)
     toolbarService.registerButton({
@@ -172,6 +187,15 @@ export class Contribution implements IContribution {
 
     toolbarService.registerButton({
       command: resourceCommand,
+      buttonType: 'text',
+      colors: {
+        foreground: 'white',
+        background: 'transparent',
+      },
+    })
+
+    toolbarService.registerButton({
+      command: backToResourcesCommand,
       buttonType: 'text',
       colors: {
         foreground: 'white',


### PR DESCRIPTION
This pull request adds a new "Back to Resources" button to the editor toolbar, allowing users to quickly navigate back to the resources page. The main changes involve creating a new command and registering it with the toolbar service.

**New Toolbar Navigation Feature:**

* Added a new `BackToResourcesCommand` class that defines a command to navigate the user to the `/resources` page when executed.
* Registered the new `backToResourcesCommand` with the command service and added a corresponding button to the toolbar with a left arrow icon and "Retour aux ressources" label. [[1]](diffhunk://#diff-0692ae093d559f91f2172f3eeb9876d2000ac4749a42b068fca8ed3ef72c797eR177) [[2]](diffhunk://#diff-0692ae093d559f91f2172f3eeb9876d2000ac4749a42b068fca8ed3ef72c797eR196-R204)