### PR TITLE
Centrale

### DIFF
--- a/apps/web/src/app/pages/builder/builder.page.ts
+++ b/apps/web/src/app/pages/builder/builder.page.ts
@@ -709,12 +709,7 @@ export class BuilderPage implements OnInit {
         console.error
       )
     }
-
-    if (this.resource) {
-      this.router.navigate(['/resources', this.resource.id]).catch(console.error)
-    } else {
-      this.router.navigate(['/resources']).catch(console.error)
-    }
+    window.history.back()
   }
 
   protected trackInput(_: number, input: PleInput): string {

--- a/apps/web/src/app/pages/editor/contributions/previews/pl-preview.contribution.ts
+++ b/apps/web/src/app/pages/editor/contributions/previews/pl-preview.contribution.ts
@@ -210,6 +210,7 @@ export class Contribution implements IContribution {
   }
 
   deactivate(): void | Promise<void> {
+    this.activated = false
     this.subscriptions.forEach((s) => s.unsubscribe())
   }
 }

--- a/apps/web/src/app/pages/editor/contributions/previews/pl-preview.contribution.ts
+++ b/apps/web/src/app/pages/editor/contributions/previews/pl-preview.contribution.ts
@@ -129,24 +129,28 @@ export class ResourceCommand implements ICommand {
 
 class BackToResourcesCommand implements ICommand {
   readonly id = 'platon.contrib.toolbar.commands.back-to-resources'
-  readonly label = 'Retour aux ressources'
+  readonly label = ''
   readonly icon = new CodIcon('arrow-left')
 
   get enabled(): boolean {
-    return true
+    return window.history.length > 1
   }
 
   async execute(): Promise<void> {
-    window.location.href = '/resources'
+    window.history.back()
   }
 }
 
 @Injectable()
 export class Contribution implements IContribution {
   private readonly subscriptions: Subscription[] = []
+  private activated = false
   readonly id = 'platon.contrib.preview'
 
   activate(injector: Injector) {
+    if (this.activated) return
+    this.activated = true
+
     const presenter = injector.get(EditorPresenter)
     const fileService = injector.get(FileService)
     const editorService = injector.get(EditorService)
@@ -172,11 +176,21 @@ export class Contribution implements IContribution {
 
     editorService.registerCommands(new PreviewInNewTabCommand(presenter, editorService))
 
+    const backToResourcesCommand = new BackToResourcesCommand()
     const previewFromToolbar = new ToolbarPreviewCommand(presenter, fileService, editorService)
     const resourceCommand = new ResourceCommand(presenter)
-    const backToResourcesCommand = new BackToResourcesCommand()
 
     commandService.register(previewFromToolbar)
+
+    toolbarService.registerButton({
+      command: backToResourcesCommand,
+      buttonType: 'text',
+      colors: {
+        foreground: 'white',
+        background: 'transparent',
+      },
+    })
+
     toolbarService.registerButton({
       command: previewFromToolbar,
       colors: {
@@ -187,15 +201,6 @@ export class Contribution implements IContribution {
 
     toolbarService.registerButton({
       command: resourceCommand,
-      buttonType: 'text',
-      colors: {
-        foreground: 'white',
-        background: 'transparent',
-      },
-    })
-
-    toolbarService.registerButton({
-      command: backToResourcesCommand,
       buttonType: 'text',
       colors: {
         foreground: 'white',

--- a/apps/web/src/app/pages/editor/contributions/previews/pl-preview.contribution.ts
+++ b/apps/web/src/app/pages/editor/contributions/previews/pl-preview.contribution.ts
@@ -127,6 +127,20 @@ export class ResourceCommand implements ICommand {
   }
 }
 
+class BackToResourcesCommand implements ICommand {
+  readonly id = 'platon.contrib.toolbar.commands.back-to-resources'
+  readonly label = 'Retour aux ressources'
+  readonly icon = new CodIcon('arrow-left')
+
+  get enabled(): boolean {
+    return true
+  }
+
+  async execute(): Promise<void> {
+    window.location.href = '/resources'
+  }
+}
+
 @Injectable()
 export class Contribution implements IContribution {
   private readonly subscriptions: Subscription[] = []
@@ -160,6 +174,7 @@ export class Contribution implements IContribution {
 
     const previewFromToolbar = new ToolbarPreviewCommand(presenter, fileService, editorService)
     const resourceCommand = new ResourceCommand(presenter)
+    const backToResourcesCommand = new BackToResourcesCommand()
 
     commandService.register(previewFromToolbar)
     toolbarService.registerButton({
@@ -172,6 +187,15 @@ export class Contribution implements IContribution {
 
     toolbarService.registerButton({
       command: resourceCommand,
+      buttonType: 'text',
+      colors: {
+        foreground: 'white',
+        background: 'transparent',
+      },
+    })
+
+    toolbarService.registerButton({
+      command: backToResourcesCommand,
       buttonType: 'text',
       colors: {
         foreground: 'white',

--- a/apps/web/src/app/pages/resources/resource/resource.page.html
+++ b/apps/web/src/app/pages/resources/resource/resource.page.html
@@ -170,13 +170,18 @@
           <i nz-icon nzType="copy" nzTheme="outline"></i>
           <span class="hide-on-mobile">Dupliquer</span>
         </button>
-        <button id="tuto-editor-button" nz-button (click)="openTab(context.editorUrl!)">
+        <a
+          id="tuto-editor-button"
+          nz-button
+          [routerLink]="urlPath(context.editorUrl!)"
+          [queryParams]="{ version: context.version }"
+        >
           <i nz-icon nzType="edit" nzTheme="outline"></i>
           @if (context.resource.templateId) {
           <span class="hide-on-mobile">Paramétrer</span>
           } @else {<span class="hide-on-mobile">Éditer</span>
           }
-        </button>
+        </a>
         <button
           id="tuto-share-button"
           *ngIf="context.resource.type !== 'CIRCLE'"

--- a/apps/web/src/app/pages/resources/resource/resource.page.ts
+++ b/apps/web/src/app/pages/resources/resource/resource.page.ts
@@ -160,7 +160,7 @@ export class ResourcePage implements OnInit, OnDestroy {
   }
 
   protected urlPath(url: string): string {
-    return url.split('?')[0]
+    return new URL(url, window.location.origin).pathname
   }
 
   protected async duplicate(): Promise<void> {

--- a/apps/web/src/app/pages/resources/resource/resource.page.ts
+++ b/apps/web/src/app/pages/resources/resource/resource.page.ts
@@ -159,6 +159,10 @@ export class ResourcePage implements OnInit, OnDestroy {
     window.open(url, '_blank')
   }
 
+  protected urlPath(url: string): string {
+    return url.split('?')[0]
+  }
+
   protected async duplicate(): Promise<void> {
     const duplicatedResourceId = await this.presenter.duplicate()
     if (duplicatedResourceId) {

--- a/libs/feature/course/browser/src/components/activity-table/activity-table.component.html
+++ b/libs/feature/course/browser/src/components/activity-table/activity-table.component.html
@@ -1,4 +1,11 @@
-<nz-table #nzTable [nzSize]="'small'" [nzShowSizeChanger]="false" [nzShowPagination]="false" [nzData]="dataSource">
+<nz-table
+  #nzTable
+  [nzSize]="'small'"
+  [nzShowSizeChanger]="false"
+  [nzShowPagination]="false"
+  [nzFrontPagination]="false"
+  [nzData]="dataSource"
+>
   <thead>
     <tr>
       <th

--- a/libs/feature/player/browser/src/components/player-exercise/player-exercise.component.html
+++ b/libs/feature/player/browser/src/components/player-exercise/player-exercise.component.html
@@ -1,6 +1,14 @@
 <mat-card #container>
   @if (hasErrors()) {
   <div class="custom-error-page">
+    <button
+      mat-icon-button
+      class="dismiss-error-button"
+      (click)="dismissErrors()"
+      nz-tooltip="Afficher l'exercice quand même"
+    >
+      <mat-icon>close</mat-icon>
+    </button>
     <div class="error-illustration">
       <mat-icon class="error-icon">bug_report</mat-icon>
     </div>

--- a/libs/feature/player/browser/src/components/player-exercise/player-exercise.component.scss
+++ b/libs/feature/player/browser/src/components/player-exercise/player-exercise.component.scss
@@ -241,10 +241,23 @@ button.primary {
 
 
 .custom-error-page {
+  position: relative;
   display: flex;
   flex-direction: column;
   align-items: center;
   justify-content: center;
+
+  .dismiss-error-button {
+    position: absolute;
+    top: 0.75rem;
+    right: 0.75rem;
+    opacity: 0.6;
+    transition: opacity 0.2s ease;
+
+    &:hover {
+      opacity: 1;
+    }
+  }
   min-height: 400px;
   padding: 2rem;
   text-align: center;

--- a/libs/feature/player/browser/src/components/player-exercise/player-exercise.component.ts
+++ b/libs/feature/player/browser/src/components/player-exercise/player-exercise.component.ts
@@ -204,6 +204,7 @@ export class PlayerExerciseComponent implements OnInit, OnDestroy, OnChanges, Af
           if (this.player?.feedbacks && this.player.feedbacks.some((feedback) => feedback.content)) {
             this.scrollIntoNode(this.containerFeedbacks?.nativeElement, 'center')
           }
+          this.errorsDismissed.set(false)
         },
       },
       {
@@ -440,7 +441,6 @@ export class PlayerExerciseComponent implements OnInit, OnDestroy, OnChanges, Af
       this.player = this.players[this.index]
 
       this.playerSignal.set(this.player)
-
       this.clearNotification?.()
       this.clearNotification = undefined
     }

--- a/libs/feature/player/browser/src/components/player-exercise/player-exercise.component.ts
+++ b/libs/feature/player/browser/src/components/player-exercise/player-exercise.component.ts
@@ -130,6 +130,7 @@ export class PlayerExerciseComponent implements OnInit, OnDestroy, OnChanges, Af
   private readonly webComponentService = inject(WebComponentService)
 
   protected readonly playerSignal = signal<ExercisePlayer | undefined>(undefined)
+  protected readonly errorsDismissed = signal(false)
   private user: User | undefined = undefined
 
   @Input() state?: AnswerStates
@@ -641,11 +642,16 @@ export class PlayerExerciseComponent implements OnInit, OnDestroy, OnChanges, Af
   })
 
   readonly hasErrors = computed(() => {
+    if (this.errorsDismissed()) return false
     const player = this.playerSignal()
     if (!player) return false
     const errorLogs = this.getErrorLogsFromPlayer(player)
     return !this.editorPreview && errorLogs.length > 0
   })
+
+  protected dismissErrors(): void {
+    this.errorsDismissed.set(true)
+  }
 
   private getErrorLogsFromPlayer(player: ExercisePlayer): PlatonLog[] {
     return player.platon_logs?.filter((log) => log.type === LogType.ERROR) || []

--- a/libs/feature/resource/browser/src/lib/api/resource.service.ts
+++ b/libs/feature/resource/browser/src/lib/api/resource.service.ts
@@ -44,7 +44,7 @@ export class ResourceService {
 
   editorUrl(resourceId: string, version?: string, templateId?: string): string {
     if (templateId) {
-      return `builder/${resourceId}?version=${version || 'latest'}`
+      return `/builder/${resourceId}?version=${version || 'latest'}`
     }
     return `/editor/${resourceId}?version=${version || 'latest'}`
   }

--- a/libs/feature/resource/browser/src/lib/components/resource-item/resource-item.component.html
+++ b/libs/feature/resource/browser/src/lib/components/resource-item/resource-item.component.html
@@ -10,13 +10,27 @@
     (didClickTitle)="itemClicked.emit()"
   >
     @if(item.templateId) {
-    <ui-list-item-article-action *ngIf="editable" (click)="openTab(builderUrl)" class="action" actionTitle="Paramétrer">
-      <i nz-icon nzType="edit" nzTheme="outline"></i>
-    </ui-list-item-article-action>
+    <a
+      *ngIf="editable"
+      [routerLink]="['/builder', item.id]"
+      [queryParams]="{ version: 'latest' }"
+      style="display: contents; color: inherit; text-decoration: none"
+    >
+      <ui-list-item-article-action class="action" actionTitle="Paramétrer">
+        <i nz-icon nzType="edit" nzTheme="outline"></i>
+      </ui-list-item-article-action>
+    </a>
     } @else {
-    <ui-list-item-article-action *ngIf="editable" (click)="openTab(editorUrl)" class="action" actionTitle="Éditer">
-      <i nz-icon nzType="edit" nzTheme="outline"></i>
-    </ui-list-item-article-action>
+    <a
+      *ngIf="editable"
+      [routerLink]="['/editor', item.id]"
+      [queryParams]="{ version: 'latest' }"
+      style="display: contents; color: inherit; text-decoration: none"
+    >
+      <ui-list-item-article-action class="action" actionTitle="Éditer">
+        <i nz-icon nzType="edit" nzTheme="outline"></i>
+      </ui-list-item-article-action>
+    </a>
     }
 
     <ng-container *ngIf="item.type !== 'CIRCLE'">

--- a/libs/feature/resource/browser/src/lib/components/template-selection/template-selection.component.ts
+++ b/libs/feature/resource/browser/src/lib/components/template-selection/template-selection.component.ts
@@ -44,17 +44,20 @@ export class TemplateSelectionComponent implements OnInit {
   protected templates: Resource[] = []
 
   async ngOnInit(): Promise<void> {
-    this.templates = (
-      await firstValueFrom(
+    const [user, templates] = await Promise.all([
+      this.authService.ready(),
+      firstValueFrom(
         this.resourceService.search({
           types: [ResourceTypes.EXERCISE],
           configurable: true,
           certifiedTemplate: true,
           expands: ['metadata', 'statistic', 'permissions'],
         })
-      )
-    ).resources
-    this.user = (await this.authService.ready()) as User
+      ),
+    ])
+
+    this.templates = templates.resources
+    this.user = user || undefined
 
     this.changeDetector.markForCheck()
   }
@@ -95,8 +98,7 @@ export class TemplateSelectionComponent implements OnInit {
           topics: [],
         })
       )
-
-      await this.router.navigate(['/builder', resource.id], { replaceUrl: true })
+      await this.router.navigate(['/builder', resource.id])
     } catch (error) {
       this.dialogService.error('Une erreur est survenue lors de la création de la ressource')
 

--- a/libs/feature/resource/server/src/lib/resource.service.ts
+++ b/libs/feature/resource/server/src/lib/resource.service.ts
@@ -356,7 +356,7 @@ export class ResourceService {
     }
 
     if (filters.certifiedTemplate != null) {
-      query.andWhere(`(type <> 'EXERCISE' OR metadata.meta->'certifiedTemplate' = :certifiedTemplate)`, {
+      query.andWhere(`(metadata.meta->'certifiedTemplate' = :certifiedTemplate)`, {
         certifiedTemplate: filters.certifiedTemplate,
       })
     }
@@ -404,6 +404,11 @@ export class ResourceService {
     if (filters.limit) {
       query.take(filters.limit)
     }
+
+    const [sql, params] = query.getQueryAndParameters()
+    console.log('Executing search query:', sql, 'with parameters:', params)
+    const explainResult = await this.dataSource.query(`EXPLAIN (ANALYZE, BUFFERS, FORMAT TEXT) ${sql}`, params)
+    console.log(explainResult.map((r: any) => Object.values(r)[0]).join('\n'))
 
     return query.getManyAndCount()
   }

--- a/libs/feature/resource/server/src/lib/resource.service.ts
+++ b/libs/feature/resource/server/src/lib/resource.service.ts
@@ -405,11 +405,6 @@ export class ResourceService {
       query.take(filters.limit)
     }
 
-    const [sql, params] = query.getQueryAndParameters()
-    console.log('Executing search query:', sql, 'with parameters:', params)
-    const explainResult = await this.dataSource.query(`EXPLAIN (ANALYZE, BUFFERS, FORMAT TEXT) ${sql}`, params)
-    console.log(explainResult.map((r: any) => Object.values(r)[0]).join('\n'))
-
     return query.getManyAndCount()
   }
 


### PR DESCRIPTION
This pull request introduces several improvements to navigation and UI consistency across resource-related pages, as well as minor enhancements to command handling and table rendering. The main changes focus on using Angular routing for navigation instead of opening new tabs, adding a "Back to Resources" command, and ensuring correct URL formatting.

**Navigation and Routing Improvements:**

* Updated resource action buttons in `resource.page.html` and `resource-item.component.html` to use Angular's `[routerLink]` instead of opening new tabs, ensuring smoother in-app navigation and proper handling of query parameters. [[1]](diffhunk://#diff-51bedef24501aa1b448c94857b803edf2676ccb9ab4afb8518a26be4d3c76a31L173-R184) [[2]](diffhunk://#diff-4e6bad1c09d08c0908e2da42bcafa8c180b94aa9395120e57859df17ae002139L13-R33)
* Added a helper method `urlPath` in `resource.page.ts` to extract the path from a URL, used for correct routing.
* Fixed the URL in `editorUrl` method of `ResourceService` to ensure it always starts with a leading slash.

**Command and Toolbar Enhancements:**

* Introduced a new `BackToResourcesCommand` and registered it as a toolbar button, allowing users to navigate back using browser history. Also added activation guards to prevent duplicate registrations. [[1]](diffhunk://#diff-0692ae093d559f91f2172f3eeb9876d2000ac4749a42b068fca8ed3ef72c797eR130-R153) [[2]](diffhunk://#diff-0692ae093d559f91f2172f3eeb9876d2000ac4749a42b068fca8ed3ef72c797eR179-R193)
* Replaced navigation logic in `BuilderPage`'s cancel handler to use `window.history.back()` for a more intuitive user experience.

**UI Consistency:**

* Updated the activity table component to explicitly disable front-end pagination, ensuring consistent table behavior.