### PR TITLE
Feature/improvment preview

### DIFF
--- a/libs/feature/email/server/src/lib/email.service.ts
+++ b/libs/feature/email/server/src/lib/email.service.ts
@@ -109,6 +109,19 @@ export class EmailService {
   }
 
   /**
+   * Envoie un e-mail à l'équipe PLaTOn, sans le dédoublonnage/throttling réservé aux alertes techniques
+   * @param options Les options de l'e-mail (sans le destinataire, résolu automatiquement)
+   * @returns Promise<boolean> true si l'envoi a réussi, false sinon
+   */
+  async sendToPlatonTeam(options: Omit<EmailOptions, 'to'>): Promise<boolean> {
+    if (!this.isConfigured || !this.technicalTeamEmail.length) {
+      this.logger.error(`Impossible d'envoyer l'e-mail "${options.subject}" à l'équipe PLaTOn : service non configuré`)
+      return false
+    }
+    return this.send({ ...options, to: this.technicalTeamEmail })
+  }
+
+  /**
    * Envoie un e-mail à l'équipe technique
    * @param options Les options de l'e-mail technique
    * @returns Promise<boolean> true si l'envoi a réussi, false sinon

--- a/libs/feature/player/browser/src/api/player.service.ts
+++ b/libs/feature/player/browser/src/api/player.service.ts
@@ -56,7 +56,7 @@ export class PlayerService {
     return this.provider.saveTemporaryAnswer(input)
   }
 
-  sendFeedback(feedback: Feedback): Observable<void> {
-    return this.provider.sendFeedback(feedback)
+  submitFeedback(feedback: Feedback): Observable<void> {
+    return this.provider.submitFeedback(feedback)
   }
 }

--- a/libs/feature/player/browser/src/api/player.service.ts
+++ b/libs/feature/player/browser/src/api/player.service.ts
@@ -11,6 +11,7 @@ import {
   PlayExerciseOuput,
   PreviewInput,
   PreviewOuput,
+  Feedback,
 } from '@platon/feature/player/common'
 import { Observable } from 'rxjs'
 import { PlayerProvider } from '../models/player-provider'
@@ -53,5 +54,9 @@ export class PlayerService {
 
   saveTemporaryAnswer(input: EvalExerciseInput): Observable<void> {
     return this.provider.saveTemporaryAnswer(input)
+  }
+
+  sendFeedback(feedback: Feedback): Observable<void> {
+    return this.provider.sendFeedback(feedback)
   }
 }

--- a/libs/feature/player/browser/src/components/player-activity/player-activity.component.html
+++ b/libs/feature/player/browser/src/components/player-activity/player-activity.component.html
@@ -122,35 +122,49 @@
     </mat-card-content>
   </mat-card>
   <ng-template #showExercices>
-    <section>
-      <ng-container *ngFor="let exercise of exercises; trackBy: trackBySessionId; let i = index">
-        <nz-ribbon [nzText]="ribbon">
-          <ng-template #ribbon>
-            @if (nextNavigation) { Exercice {{ player.navigation.nextExercisesHistoryPosition + 1 }}
-            } @else {
-            {{ composed ? i + 1 : position + 1 }} / {{ navExerciceCount }}
-            }
-          </ng-template>
-          <player-exercise
-            #playerExercise
-            [id]="exercise.sessionId"
-            [player]="exercise"
-            [state]="answerStates[exercise.sessionId]"
-            (evaluated)="onChangeNavigation($event)"
-            [hasPrev]="hasPrev"
-            [hasNext]="hasNext"
-            (goToPrevPlayer)="play(player.navigation.exercises[position - 1], true)"
-            (goToNextPlayer)="play(player.navigation.exercises[position + 1])"
-          />
-        </nz-ribbon>
-      </ng-container>
-    </section>
+    <div [class.leave-warning-frame]="showLeaveWarning()">
+      @if (showLeaveWarning()) {
+      <div class="leave-warning-banner" role="alert" aria-live="polite">
+        <span class="leave-warning-icon" aria-hidden="true"><mat-icon>info</mat-icon></span>
+        <p>
+          Vous n'êtes pas autorisé à quitter cette page. Si vous quittez, votre activité sera automatiquement terminée.
+        </p>
+      </div>
+      }
+      <section>
+        <ng-container *ngFor="let exercise of exercises; trackBy: trackBySessionId; let i = index">
+          <nz-ribbon [nzText]="ribbon">
+            <ng-template #ribbon>
+              @if (nextNavigation) { Exercice {{ player.navigation.nextExercisesHistoryPosition + 1 }}
+              } @else {
+              {{ composed ? i + 1 : position + 1 }} / {{ navExerciceCount }}
+              }
+            </ng-template>
+            <player-exercise
+              #playerExercise
+              [id]="exercise.sessionId"
+              [player]="exercise"
+              [state]="answerStates[exercise.sessionId]"
+              (evaluated)="onChangeNavigation($event)"
+              [hasPrev]="hasPrev"
+              [hasNext]="hasNext"
+              (goToPrevPlayer)="play(player.navigation.exercises[position - 1], true)"
+              (goToNextPlayer)="play(player.navigation.exercises[position + 1])"
+            />
+          </nz-ribbon>
+        </ng-container>
+      </section>
 
-    @if(canShowTerminalLogs()) {
-    <player-terminal-logs [logs]="activityLogs" title="Terminal Next" />
-    }
+      @if(canShowTerminalLogs()) {
+      <player-terminal-logs [logs]="activityLogs" title="Terminal Next" />
+      }
+    </div>
   </ng-template>
 </main>
+
+@if (showLeaveWarning()) {
+<div class="leave-warning-overlay" aria-hidden="true"></div>
+}
 <footer [class.glass]="countdown" *ngIf="exercises">
   <nz-countdown
     *ngIf="countdown"

--- a/libs/feature/player/browser/src/components/player-activity/player-activity.component.scss
+++ b/libs/feature/player/browser/src/components/player-activity/player-activity.component.scss
@@ -352,6 +352,60 @@ pre {
   margin: 2rem 0;
 }
 
+.leave-warning-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.45);
+  z-index: 10;
+  pointer-events: none;
+}
+
+.leave-warning-frame {
+  position: relative;
+  z-index: 11;
+  border: 5px dashed #000000;
+  border-radius: 8px;
+  padding: 0.5rem;
+}
+
+.leave-warning-banner {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.875rem 1.25rem;
+  margin-top: 0.5rem;
+  margin-bottom: 1rem;
+  background-color: #fff3cd;
+  border: 1px solid #ffeeba;
+  border-radius: 6px;
+  color: #856404;
+
+  .leave-warning-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex-shrink: 0;
+    width: 2rem;
+    height: 2rem;
+    background: #856404;
+    border-radius: 50%;
+
+    mat-icon {
+      color: #fff3cd;
+      font-size: 1.1rem;
+      width: 1.1rem;
+      height: 1.1rem;
+      line-height: 1.1rem;
+    }
+  }
+
+  p {
+    margin: 0;
+    font-size: 0.9rem;
+    line-height: 1.4;
+  }
+}
+
 
 @media (max-width: 768px) {
   :host {

--- a/libs/feature/player/browser/src/components/player-activity/player-activity.component.ts
+++ b/libs/feature/player/browser/src/components/player-activity/player-activity.component.ts
@@ -9,6 +9,7 @@ import {
   OnDestroy,
   OnInit,
   QueryList,
+  signal,
   TemplateRef,
   ViewChild,
   ViewChildren,
@@ -115,8 +116,12 @@ export class PlayerActivityComponent implements OnInit, OnDestroy {
   protected navExerciceCount = 0
   protected terminatedAfterLoseFocus = false
   protected terminatedAfterLeavePage = false
+  protected readonly showLeaveWarning = signal(false)
   protected onLoseTabFocusFn = this.onLoseTabFocus.bind(this)
   protected onVisibilityChangeFn = this.onVisibilityChange.bind(this)
+  private readonly onBeforeUnloadFn = this.onBeforeUnload.bind(this)
+  private readonly onDocumentPointerLeaveFn = this.onDocumentPointerLeave.bind(this)
+  private readonly onDocumentPointerEnterFn = this.onDocumentPointerEnter.bind(this)
   protected onKeydownFn = this.onKeydown.bind(this)
   protected onContextMenuFn = this.onContextMenu.bind(this)
   protected loadingNext = false
@@ -320,6 +325,7 @@ export class PlayerActivityComponent implements OnInit, OnDestroy {
   }
 
   protected async terminate(): Promise<void> {
+    this.showLeaveWarning.set(false)
     this.countdownBreakpoints = []
 
     const output = await firstValueFrom(this.playerService.terminate(this.player.sessionId))
@@ -616,14 +622,32 @@ export class PlayerActivityComponent implements OnInit, OnDestroy {
     this.terminate().catch(console.error)
   }
 
-  private onVisibilityChange(): void {
-    if (!this.isPlaying || !this.player.settings?.security?.terminateOnLeavePage) return
+  private shouldWarnOnLeave(): boolean {
+    return this.isPlaying && !!this.player.settings?.security?.terminateOnLeavePage
+  }
 
-    // passed from hidden to visible
+  private onVisibilityChange(): void {
+    if (!this.shouldWarnOnLeave()) return
+
     if (document.visibilityState === 'hidden') {
       this.terminatedAfterLeavePage = true
       this.terminate().catch(console.error)
     }
+  }
+
+  private onBeforeUnload(event: BeforeUnloadEvent): void {
+    if (!this.shouldWarnOnLeave()) return
+    event.preventDefault()
+    event.returnValue = ''
+  }
+
+  private onDocumentPointerLeave(): void {
+    if (!this.shouldWarnOnLeave()) return
+    this.showLeaveWarning.set(true)
+  }
+
+  private onDocumentPointerEnter(): void {
+    this.showLeaveWarning.set(false)
   }
 
   private enableCopyPasteIfNeeded(): void {
@@ -646,12 +670,18 @@ export class PlayerActivityComponent implements OnInit, OnDestroy {
 
   private startWatchingVisibilityChange(): void {
     window.addEventListener('blur', this.onLoseTabFocusFn)
+    window.addEventListener('beforeunload', this.onBeforeUnloadFn)
     document.addEventListener('visibilitychange', this.onVisibilityChangeFn)
+    document.documentElement.addEventListener('pointerleave', this.onDocumentPointerLeaveFn)
+    document.documentElement.addEventListener('pointerenter', this.onDocumentPointerEnterFn)
   }
 
   private stopWatchingVisibilityChange(): void {
     window.removeEventListener('blur', this.onLoseTabFocusFn)
+    window.removeEventListener('beforeunload', this.onBeforeUnloadFn)
     document.removeEventListener('visibilitychange', this.onVisibilityChangeFn)
+    document.documentElement.removeEventListener('pointerleave', this.onDocumentPointerLeaveFn)
+    document.documentElement.removeEventListener('pointerenter', this.onDocumentPointerEnterFn)
   }
 
   protected back() {

--- a/libs/feature/player/browser/src/components/player-exercise/player-exercise.component.html
+++ b/libs/feature/player/browser/src/components/player-exercise/player-exercise.component.html
@@ -185,7 +185,7 @@
         <mat-divider></mat-divider>
 
         <div class="exercice-actions-list-below">
-          @if(player) {
+          @if(player && user) {
           <player-question-feedback
             [sessionId]="player.sessionId"
             [exerciseTitle]="player.title"

--- a/libs/feature/player/browser/src/components/player-exercise/player-exercise.component.html
+++ b/libs/feature/player/browser/src/components/player-exercise/player-exercise.component.html
@@ -185,6 +185,13 @@
         <mat-divider></mat-divider>
 
         <div class="exercice-actions-list-below">
+          @if(player) {
+          <player-question-feedback
+            [sessionId]="player.sessionId"
+            [exerciseTitle]="player.title"
+            [author]="player.author"
+          />
+          }
           <div class="spacer"></div>
           <ng-container *ngTemplateOutlet="actionList; context: { $implicit: navigationActions }" />
         </div>

--- a/libs/feature/player/browser/src/components/player-exercise/player-exercise.component.scss
+++ b/libs/feature/player/browser/src/components/player-exercise/player-exercise.component.scss
@@ -127,6 +127,8 @@ pre {
 .exercice-actions-list-below {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
+  row-gap: 0.5rem;
   &.align-right {
     justify-content: flex-end;
   }

--- a/libs/feature/player/browser/src/components/player-exercise/player-exercise.component.ts
+++ b/libs/feature/player/browser/src/components/player-exercise/player-exercise.component.ts
@@ -54,6 +54,7 @@ import { NzToolTipModule } from 'ng-zorro-antd/tooltip'
 import { PlayerService } from '../../api/player.service'
 import { PLAYER_EDITOR_PREVIEW } from '../../models/player.model'
 import { PlayerCommentsComponent } from '../player-comments/player-comments.component'
+import { PlayerQuestionFeedbackComponent } from '../player-question-feedback/player-question-feedback.component'
 import { PlayerTheoryComponent } from '../player-theory/player-theory.component'
 import { PlayerTerminalLogsComponent } from '../player-terminal-logs/player-terminal-logs.component'
 import { User } from '@platon/core/common'
@@ -116,6 +117,7 @@ type FullscreenElement = HTMLElement & {
     AnswerStatePipesModule,
     PlayerCommentsComponent,
     PlayerTerminalLogsComponent,
+    PlayerQuestionFeedbackComponent,
   ],
   schemas: [CUSTOM_ELEMENTS_SCHEMA],
 })
@@ -184,6 +186,22 @@ export class PlayerExerciseComponent implements OnInit, OnDestroy, OnChanges, Af
 
   protected get primaryActions(): Action[] {
     if (!this.player) return []
+    let saveAnswerAction: Action | undefined = undefined
+    if (!this.previewMode) {
+      saveAnswerAction = {
+        icon: 'save',
+        label: 'Sauvegarder',
+        tooltip: 'Sauvegarder',
+        visible: !this.reviewMode,
+        disabled: !!this.runningAction,
+        playerAction: PlayerActions.SAVE_ANSWER,
+        showLabel: this.showLabelIfEnoughSpace,
+        run: async () => {
+          await this.saveTemporaryAnswer(PlayerActions.SAVE_ANSWER)
+          this.dialogService.success('Votre réponse a bien été sauvegardée.')
+        },
+      }
+    }
     return [
       {
         id: 'check-answer-button',
@@ -207,19 +225,7 @@ export class PlayerExerciseComponent implements OnInit, OnDestroy, OnChanges, Af
           this.errorsDismissed.set(false)
         },
       },
-      {
-        icon: 'save',
-        label: 'Sauvegarder',
-        tooltip: 'Sauvegarder',
-        visible: !this.reviewMode,
-        disabled: !!this.runningAction,
-        playerAction: PlayerActions.SAVE_ANSWER,
-        showLabel: this.showLabelIfEnoughSpace,
-        run: async () => {
-          await this.saveTemporaryAnswer(PlayerActions.SAVE_ANSWER)
-          this.dialogService.success('Votre réponse a bien été sauvegardée.')
-        },
-      },
+      ...(saveAnswerAction ? [saveAnswerAction] : []),
       {
         icon: 'refresh',
         label: 'Recharger',

--- a/libs/feature/player/browser/src/components/player-exercise/player-exercise.component.ts
+++ b/libs/feature/player/browser/src/components/player-exercise/player-exercise.component.ts
@@ -186,22 +186,6 @@ export class PlayerExerciseComponent implements OnInit, OnDestroy, OnChanges, Af
 
   protected get primaryActions(): Action[] {
     if (!this.player) return []
-    let saveAnswerAction: Action | undefined = undefined
-    if (!this.previewMode) {
-      saveAnswerAction = {
-        icon: 'save',
-        label: 'Sauvegarder',
-        tooltip: 'Sauvegarder',
-        visible: !this.reviewMode,
-        disabled: !!this.runningAction,
-        playerAction: PlayerActions.SAVE_ANSWER,
-        showLabel: this.showLabelIfEnoughSpace,
-        run: async () => {
-          await this.saveTemporaryAnswer(PlayerActions.SAVE_ANSWER)
-          this.dialogService.success('Votre réponse a bien été sauvegardée.')
-        },
-      }
-    }
     return [
       {
         id: 'check-answer-button',
@@ -225,7 +209,19 @@ export class PlayerExerciseComponent implements OnInit, OnDestroy, OnChanges, Af
           this.errorsDismissed.set(false)
         },
       },
-      ...(saveAnswerAction ? [saveAnswerAction] : []),
+      {
+        icon: 'save',
+        label: 'Sauvegarder',
+        tooltip: 'Sauvegarder',
+        visible: !this.reviewMode && !this.previewMode,
+        disabled: !!this.runningAction,
+        playerAction: PlayerActions.SAVE_ANSWER,
+        showLabel: this.showLabelIfEnoughSpace,
+        run: async () => {
+          await this.saveTemporaryAnswer(PlayerActions.SAVE_ANSWER)
+          this.dialogService.success('Votre réponse a bien été sauvegardée.')
+        },
+      },
       {
         icon: 'refresh',
         label: 'Recharger',

--- a/libs/feature/player/browser/src/components/player-exercise/player-exercise.component.ts
+++ b/libs/feature/player/browser/src/components/player-exercise/player-exercise.component.ts
@@ -133,7 +133,7 @@ export class PlayerExerciseComponent implements OnInit, OnDestroy, OnChanges, Af
 
   protected readonly playerSignal = signal<ExercisePlayer | undefined>(undefined)
   protected readonly errorsDismissed = signal(false)
-  private user: User | undefined = undefined
+  protected user: User | undefined = undefined
 
   @Input() state?: AnswerStates
   @Input() player?: ExercisePlayer

--- a/libs/feature/player/browser/src/components/player-question-feedback/player-question-feedback.component.html
+++ b/libs/feature/player/browser/src/components/player-question-feedback/player-question-feedback.component.html
@@ -1,0 +1,48 @@
+<div class="question-feedback">
+  <button type="button" class="trigger" (click)="toggle()">
+    <mat-icon>flag</mat-icon>
+    <span>Signaler un problème avec cet exercice</span>
+  </button>
+
+  @if(expanded()){
+  <div class="panel">
+    @if(!submitted()){
+    <p class="intro">PLaTOn est à l'écoute de vos remarques pour améliorer les exercices proposés&nbsp;!</p>
+
+    <nz-select
+      class="category-select"
+      [(ngModel)]="category"
+      nzPlaceHolder="J'ai un problème avec"
+      (ngModelChange)="onCategoryChange()"
+    >
+      @for (cat of categories; track cat.value) {
+      <nz-option [nzLabel]="cat.label" [nzValue]="cat.value" />
+      }
+    </nz-select>
+
+    @if(category()){
+    <p class="char-limit">Votre message est limité à {{ maxLength }} caractères.</p>
+    <textarea
+      nz-input
+      class="message-input"
+      [ngModel]="message()"
+      (ngModelChange)="message.set($event)"
+      [maxlength]="maxLength"
+      rows="4"
+      placeholder="Décrivez votre problème ou votre suggestion"
+    ></textarea>
+    <span class="counter">{{ message().length }} / {{ maxLength }}</span>
+
+    <button nz-button nzType="primary" class="submit-button" [disabled]="!message().trim()" (click)="submit()">
+      Envoyer
+    </button>
+    } } @else{
+    <div class="thanks">
+      <mat-icon>check_circle</mat-icon>
+      <p>Merci, votre signalement a bien été pris en compte !</p>
+      <button nz-button (click)="close()">Fermer</button>
+    </div>
+    }
+  </div>
+  }
+</div>

--- a/libs/feature/player/browser/src/components/player-question-feedback/player-question-feedback.component.scss
+++ b/libs/feature/player/browser/src/components/player-question-feedback/player-question-feedback.component.scss
@@ -1,0 +1,97 @@
+
+:host {
+  display: contents;
+  font-family: var(--brand-font);
+}
+
+.trigger {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+  background: none;
+  border: none;
+  color: var(--brand-text-secondary);
+  padding: 0;
+  font-size: 0.85rem;
+  cursor: pointer;
+  text-decoration: underline;
+
+  mat-icon {
+    font-size: 1.1rem;
+    height: 1.1rem;
+    width: 1.1rem;
+    color: var(--brand-text-secondary);
+  }
+
+  &:hover {
+    color: var(--brand-color-tertiary);
+
+    mat-icon {
+      color: var(--brand-color-tertiary);
+    }
+  }
+}
+
+.panel {
+  flex: 1 0 100%;
+  margin-top: 0.75rem;
+  background: var(--brand-background-card);
+  border: 1px solid var(--brand-border-color);
+  border-radius: 8px;
+  padding: 1rem;
+}
+
+.intro {
+  margin: 0 0 0.75rem;
+  font-size: 0.85rem;
+  color: var(--brand-text-primary);
+}
+
+.category-select {
+  width: 100%;
+}
+
+.char-limit {
+  margin: 0.75rem 0 0.4rem;
+  font-size: 0.75rem;
+  color: var(--brand-text-secondary);
+}
+
+.message-input {
+  width: 100%;
+  resize: vertical;
+  box-sizing: border-box;
+}
+
+.counter {
+  display: block;
+  text-align: right;
+  font-size: 0.75rem;
+  color: var(--brand-text-secondary);
+  margin: 0.25rem 0 0.75rem;
+}
+
+.submit-button {
+  width: auto;
+}
+
+.thanks {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 0.5rem;
+
+  mat-icon {
+    color: var(--brand-color-tertiary);
+    font-size: 2rem;
+    height: 2rem;
+    width: 2rem;
+  }
+
+  p {
+    margin: 0;
+    font-size: 0.85rem;
+    color: var(--brand-text-primary);
+  }
+}

--- a/libs/feature/player/browser/src/components/player-question-feedback/player-question-feedback.component.spec.ts
+++ b/libs/feature/player/browser/src/components/player-question-feedback/player-question-feedback.component.spec.ts
@@ -1,0 +1,21 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { PlayerQuestionFeedbackComponent } from './player-question-feedback.component'
+
+describe('PlayerQuestionFeedbackComponent', () => {
+  let component: PlayerQuestionFeedbackComponent
+  let fixture: ComponentFixture<PlayerQuestionFeedbackComponent>
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [PlayerQuestionFeedbackComponent],
+    }).compileComponents()
+
+    fixture = TestBed.createComponent(PlayerQuestionFeedbackComponent)
+    component = fixture.componentInstance
+    fixture.detectChanges()
+  })
+
+  it('should create', () => {
+    expect(component).toBeTruthy()
+  })
+})

--- a/libs/feature/player/browser/src/components/player-question-feedback/player-question-feedback.component.spec.ts
+++ b/libs/feature/player/browser/src/components/player-question-feedback/player-question-feedback.component.spec.ts
@@ -1,21 +1,103 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { ComponentFixture, TestBed } from '@angular/core/testing'
+import { of, throwError } from 'rxjs'
+import { FeedbackCategoryValue } from '@platon/feature/player/common'
+import { PlayerService } from '../../api/player.service'
 import { PlayerQuestionFeedbackComponent } from './player-question-feedback.component'
 
 describe('PlayerQuestionFeedbackComponent', () => {
   let component: PlayerQuestionFeedbackComponent
   let fixture: ComponentFixture<PlayerQuestionFeedbackComponent>
+  let playerService: { submitFeedback: jest.Mock }
+  let internals: any
 
   beforeEach(async () => {
+    playerService = { submitFeedback: jest.fn() }
+
     await TestBed.configureTestingModule({
       imports: [PlayerQuestionFeedbackComponent],
+      providers: [{ provide: PlayerService, useValue: playerService }],
     }).compileComponents()
 
     fixture = TestBed.createComponent(PlayerQuestionFeedbackComponent)
     component = fixture.componentInstance
+    internals = component
     fixture.detectChanges()
   })
 
   it('should create', () => {
     expect(component).toBeTruthy()
+  })
+
+  it('should toggle the expanded panel open and closed', () => {
+    expect(internals.expanded()).toBe(false)
+
+    internals.toggle()
+    expect(internals.expanded()).toBe(true)
+
+    internals.toggle()
+    expect(internals.expanded()).toBe(false)
+  })
+
+  it('should reset the message when the category changes', () => {
+    internals.message.set('un brouillon')
+    internals.onCategoryChange()
+    expect(internals.message()).toBe('')
+  })
+
+  describe('submit', () => {
+    it('should do nothing when no category is selected', async () => {
+      internals.message.set('un message')
+      await internals.submit()
+      expect(playerService.submitFeedback).not.toHaveBeenCalled()
+    })
+
+    it('should do nothing when the message is empty', async () => {
+      internals.category.set(FeedbackCategoryValue.STATEMENT)
+      await internals.submit()
+      expect(playerService.submitFeedback).not.toHaveBeenCalled()
+    })
+
+    it('should submit the feedback and mark it as submitted on success', async () => {
+      playerService.submitFeedback.mockReturnValue(of(undefined))
+      internals.category.set(FeedbackCategoryValue.STATEMENT)
+      internals.message.set("L'énoncé n'est pas clair")
+
+      await internals.submit()
+
+      expect(playerService.submitFeedback).toHaveBeenCalledWith(
+        expect.objectContaining({
+          category: FeedbackCategoryValue.STATEMENT,
+          message: "L'énoncé n'est pas clair",
+        })
+      )
+      expect(internals.submitted()).toBe(true)
+    })
+
+    it('should not mark as submitted when the request fails', async () => {
+      playerService.submitFeedback.mockReturnValue(throwError(() => new Error('network error')))
+      internals.category.set(FeedbackCategoryValue.STATEMENT)
+      internals.message.set("L'énoncé n'est pas clair")
+
+      await internals.submit()
+
+      expect(internals.submitted()).toBe(false)
+    })
+  })
+
+  describe('close', () => {
+    it('should reset expanded, submitted, category and message', () => {
+      internals.expanded.set(true)
+      internals.submitted.set(true)
+      internals.category.set(FeedbackCategoryValue.OTHER)
+      internals.message.set('test')
+
+      internals.close()
+
+      expect(internals.expanded()).toBe(false)
+      expect(internals.submitted()).toBe(false)
+      expect(internals.category()).toBeNull()
+      expect(internals.message()).toBe('')
+    })
   })
 })

--- a/libs/feature/player/browser/src/components/player-question-feedback/player-question-feedback.component.ts
+++ b/libs/feature/player/browser/src/components/player-question-feedback/player-question-feedback.component.ts
@@ -3,14 +3,10 @@ import { ChangeDetectionStrategy, Component, input, signal } from '@angular/core
 import { FormsModule } from '@angular/forms'
 
 import { MatIconModule } from '@angular/material/icon'
+import { FEEDBACK_CATEGORIES, FeedbackCategoryValue } from '@platon/feature/player/common'
 import { NzButtonModule } from 'ng-zorro-antd/button'
 import { NzInputModule } from 'ng-zorro-antd/input'
 import { NzSelectModule } from 'ng-zorro-antd/select'
-
-interface FeedbackCategory {
-  readonly value: string
-  readonly label: string
-}
 
 @Component({
   selector: 'player-question-feedback',
@@ -27,18 +23,12 @@ export class PlayerQuestionFeedbackComponent {
 
   protected readonly maxLength = 10000
 
-  protected readonly categories: FeedbackCategory[] = [
-    { value: 'statement', label: "L'énoncé de l'exercice" },
-    { value: 'answer', label: 'Les modalités de réponse' },
-    { value: 'accessibility', label: "L'accessibilité de l'exercice" },
-    { value: 'technical', label: "Le fonctionnement de l'exercice" },
-    { value: 'other', label: 'Autre chose' },
-  ]
+  protected readonly categories = FEEDBACK_CATEGORIES
 
   protected readonly expanded = signal(false)
   protected readonly submitted = signal(false)
 
-  protected category = signal<string | null>(null)
+  protected category = signal<FeedbackCategoryValue | null>(null)
   protected readonly message = signal('')
 
   protected toggle(): void {

--- a/libs/feature/player/browser/src/components/player-question-feedback/player-question-feedback.component.ts
+++ b/libs/feature/player/browser/src/components/player-question-feedback/player-question-feedback.component.ts
@@ -3,10 +3,11 @@ import { ChangeDetectionStrategy, Component, input, signal } from '@angular/core
 import { FormsModule } from '@angular/forms'
 
 import { MatIconModule } from '@angular/material/icon'
-import { FEEDBACK_CATEGORIES, FeedbackCategoryValue } from '@platon/feature/player/common'
+import { Feedback, FEEDBACK_CATEGORIES, FeedbackCategoryValue } from '@platon/feature/player/common'
 import { NzButtonModule } from 'ng-zorro-antd/button'
 import { NzInputModule } from 'ng-zorro-antd/input'
 import { NzSelectModule } from 'ng-zorro-antd/select'
+import { PlayerService } from '../../api/player.service'
 
 @Component({
   selector: 'player-question-feedback',
@@ -20,6 +21,8 @@ export class PlayerQuestionFeedbackComponent {
   sessionId = input<string | undefined>(undefined)
   exerciseTitle = input<string | undefined>(undefined)
   author = input<string | null | undefined>(undefined)
+
+  constructor(private readonly playerService: PlayerService) {}
 
   protected readonly maxLength = 10000
 
@@ -43,7 +46,7 @@ export class PlayerQuestionFeedbackComponent {
     this.message.set('')
   }
 
-  protected submit(): void {
+  protected async submit(): Promise<void> {
     if (!this.category || !this.message().trim()) {
       return
     }
@@ -53,10 +56,38 @@ export class PlayerQuestionFeedbackComponent {
       author: this.author(),
       category: this.category(),
       message: this.message(),
-    }
+    } as Feedback
     console.log('Signalement de problème (front uniquement) :', payload)
+    this.playerService.submitFeedback(payload).subscribe({
+      next: () => {
+        this.submitted.set(true)
+      },
+      error: (error) => {
+        console.error("Erreur lors de l'envoi du feedback :", error)
+      },
+    })
     this.submitted.set(true)
   }
+
+  // protected async submit(): Promise<void> {
+  //   if (!this.category || !this.message().trim()) {
+  //     return
+  //   }
+  //   const payload = {
+  //     sessionId: this.sessionId(),
+  //     exerciseTitle: this.exerciseTitle(),
+  //     author: this.author(),
+  //     category: this.category(),
+  //     message: this.message(),
+  //   } as Feedback
+  //   console.log('Signalement de problème (front uniquement) :', payload)
+  //   try {
+  //     await this.playerService.submitFeedback(payload)
+  //     this.submitted.set(true)
+  //   } catch (error) {
+  //     console.error("Erreur lors de l'envoi du feedback :", error)
+  //   }
+  // }
 
   protected close(): void {
     this.expanded.set(false)

--- a/libs/feature/player/browser/src/components/player-question-feedback/player-question-feedback.component.ts
+++ b/libs/feature/player/browser/src/components/player-question-feedback/player-question-feedback.component.ts
@@ -8,6 +8,7 @@ import { NzButtonModule } from 'ng-zorro-antd/button'
 import { NzInputModule } from 'ng-zorro-antd/input'
 import { NzSelectModule } from 'ng-zorro-antd/select'
 import { PlayerService } from '../../api/player.service'
+import { firstValueFrom } from 'rxjs'
 
 @Component({
   selector: 'player-question-feedback',
@@ -57,37 +58,13 @@ export class PlayerQuestionFeedbackComponent {
       category: this.category(),
       message: this.message(),
     } as Feedback
-    console.log('Signalement de problème (front uniquement) :', payload)
-    this.playerService.submitFeedback(payload).subscribe({
-      next: () => {
-        this.submitted.set(true)
-      },
-      error: (error) => {
-        console.error("Erreur lors de l'envoi du feedback :", error)
-      },
-    })
-    this.submitted.set(true)
+    try {
+      await firstValueFrom(this.playerService.submitFeedback(payload))
+      this.submitted.set(true)
+    } catch (error) {
+      console.error("Erreur lors de l'envoi du feedback :", error)
+    }
   }
-
-  // protected async submit(): Promise<void> {
-  //   if (!this.category || !this.message().trim()) {
-  //     return
-  //   }
-  //   const payload = {
-  //     sessionId: this.sessionId(),
-  //     exerciseTitle: this.exerciseTitle(),
-  //     author: this.author(),
-  //     category: this.category(),
-  //     message: this.message(),
-  //   } as Feedback
-  //   console.log('Signalement de problème (front uniquement) :', payload)
-  //   try {
-  //     await this.playerService.submitFeedback(payload)
-  //     this.submitted.set(true)
-  //   } catch (error) {
-  //     console.error("Erreur lors de l'envoi du feedback :", error)
-  //   }
-  // }
 
   protected close(): void {
     this.expanded.set(false)

--- a/libs/feature/player/browser/src/components/player-question-feedback/player-question-feedback.component.ts
+++ b/libs/feature/player/browser/src/components/player-question-feedback/player-question-feedback.component.ts
@@ -48,7 +48,7 @@ export class PlayerQuestionFeedbackComponent {
   }
 
   protected async submit(): Promise<void> {
-    if (!this.category || !this.message().trim()) {
+    if (!this.category() || !this.message().trim()) {
       return
     }
     const payload = {

--- a/libs/feature/player/browser/src/components/player-question-feedback/player-question-feedback.component.ts
+++ b/libs/feature/player/browser/src/components/player-question-feedback/player-question-feedback.component.ts
@@ -1,0 +1,77 @@
+import { CommonModule } from '@angular/common'
+import { ChangeDetectionStrategy, Component, input, signal } from '@angular/core'
+import { FormsModule } from '@angular/forms'
+
+import { MatIconModule } from '@angular/material/icon'
+import { NzButtonModule } from 'ng-zorro-antd/button'
+import { NzInputModule } from 'ng-zorro-antd/input'
+import { NzSelectModule } from 'ng-zorro-antd/select'
+
+interface FeedbackCategory {
+  readonly value: string
+  readonly label: string
+}
+
+@Component({
+  selector: 'player-question-feedback',
+  standalone: true,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [CommonModule, FormsModule, MatIconModule, NzButtonModule, NzInputModule, NzSelectModule],
+  templateUrl: './player-question-feedback.component.html',
+  styleUrl: './player-question-feedback.component.scss',
+})
+export class PlayerQuestionFeedbackComponent {
+  sessionId = input<string | undefined>(undefined)
+  exerciseTitle = input<string | undefined>(undefined)
+  author = input<string | null | undefined>(undefined)
+
+  protected readonly maxLength = 10000
+
+  protected readonly categories: FeedbackCategory[] = [
+    { value: 'statement', label: "L'énoncé de l'exercice" },
+    { value: 'answer', label: 'Les modalités de réponse' },
+    { value: 'accessibility', label: "L'accessibilité de l'exercice" },
+    { value: 'technical', label: "Le fonctionnement de l'exercice" },
+    { value: 'other', label: 'Autre chose' },
+  ]
+
+  protected readonly expanded = signal(false)
+  protected readonly submitted = signal(false)
+
+  protected category = signal<string | null>(null)
+  protected readonly message = signal('')
+
+  protected toggle(): void {
+    if (this.expanded()) {
+      this.close()
+      return
+    }
+    this.expanded.set(true)
+  }
+
+  protected onCategoryChange(): void {
+    this.message.set('')
+  }
+
+  protected submit(): void {
+    if (!this.category || !this.message().trim()) {
+      return
+    }
+    const payload = {
+      sessionId: this.sessionId(),
+      exerciseTitle: this.exerciseTitle(),
+      author: this.author(),
+      category: this.category(),
+      message: this.message(),
+    }
+    console.log('Signalement de problème (front uniquement) :', payload)
+    this.submitted.set(true)
+  }
+
+  protected close(): void {
+    this.expanded.set(false)
+    this.submitted.set(false)
+    this.category.set(null)
+    this.message.set('')
+  }
+}

--- a/libs/feature/player/browser/src/models/player-provider.ts
+++ b/libs/feature/player/browser/src/models/player-provider.ts
@@ -24,5 +24,5 @@ export abstract class PlayerProvider {
   abstract evaluate(input: EvalExerciseInput): Observable<EvalExerciseOutput>
   abstract terminate(sessionId: string): Observable<PlayActivityOuput>
   abstract saveTemporaryAnswer(input: EvalExerciseInput): Observable<void>
-  abstract sendFeedback(feedback: Feedback): Observable<void>
+  abstract submitFeedback(feedback: Feedback): Observable<void>
 }

--- a/libs/feature/player/browser/src/models/player-provider.ts
+++ b/libs/feature/player/browser/src/models/player-provider.ts
@@ -1,6 +1,7 @@
 import {
   EvalExerciseInput,
   EvalExerciseOutput,
+  Feedback,
   NextOutput,
   PlayActivityInput,
   PlayActivityOuput,
@@ -23,4 +24,5 @@ export abstract class PlayerProvider {
   abstract evaluate(input: EvalExerciseInput): Observable<EvalExerciseOutput>
   abstract terminate(sessionId: string): Observable<PlayActivityOuput>
   abstract saveTemporaryAnswer(input: EvalExerciseInput): Observable<void>
+  abstract sendFeedback(feedback: Feedback): Observable<void>
 }

--- a/libs/feature/player/browser/src/providers/remote-player.provider.ts
+++ b/libs/feature/player/browser/src/providers/remote-player.provider.ts
@@ -57,7 +57,8 @@ export class RemotePlayerService extends PlayerProvider {
   saveTemporaryAnswer(input: EvalExerciseInput): Observable<void> {
     return this.http.post<void>('/api/v1/player/saveTemporaryAnswer', input)
   }
-  sendFeedback(feedback: Feedback): Observable<void> {
+
+  submitFeedback(feedback: Feedback): Observable<void> {
     return this.http.post<void>('/api/v1/player/feedback', feedback)
   }
 }

--- a/libs/feature/player/browser/src/providers/remote-player.provider.ts
+++ b/libs/feature/player/browser/src/providers/remote-player.provider.ts
@@ -3,6 +3,7 @@ import { Injectable } from '@angular/core'
 import {
   EvalExerciseInput,
   EvalExerciseOutput,
+  Feedback,
   NextOutput,
   PlayActivityInput,
   PlayActivityOuput,
@@ -55,5 +56,8 @@ export class RemotePlayerService extends PlayerProvider {
 
   saveTemporaryAnswer(input: EvalExerciseInput): Observable<void> {
     return this.http.post<void>('/api/v1/player/saveTemporaryAnswer', input)
+  }
+  sendFeedback(feedback: Feedback): Observable<void> {
+    return this.http.post<void>('/api/v1/player/feedback', feedback)
   }
 }

--- a/libs/feature/player/common/src/index.ts
+++ b/libs/feature/player/common/src/index.ts
@@ -1,3 +1,4 @@
+export * from './lib/feedback.model'
 export * from './lib/player-answer.model'
 export * from './lib/player-guards.model'
 export * from './lib/player-manager.model'

--- a/libs/feature/player/common/src/lib/feedback.model.ts
+++ b/libs/feature/player/common/src/lib/feedback.model.ts
@@ -3,7 +3,6 @@ export enum FeedbackCategoryValue {
   ANSWER = 'answer',
   ACCESSIBILITY = 'accessibility',
   TECHNICAL = 'technical',
-  SUGGESTION = 'suggestion',
   OTHER = 'other',
 }
 
@@ -12,7 +11,6 @@ export const feedbackCategoryLabels: Record<FeedbackCategoryValue, string> = {
   [FeedbackCategoryValue.ANSWER]: 'Les modalités de réponse',
   [FeedbackCategoryValue.ACCESSIBILITY]: "L'accessibilité de l'exercice",
   [FeedbackCategoryValue.TECHNICAL]: "Le fonctionnement de l'exercice",
-  [FeedbackCategoryValue.SUGGESTION]: 'Une suggestion d’amélioration',
   [FeedbackCategoryValue.OTHER]: 'Autre chose',
 }
 

--- a/libs/feature/player/common/src/lib/feedback.model.ts
+++ b/libs/feature/player/common/src/lib/feedback.model.ts
@@ -33,5 +33,5 @@ export interface Feedback {
   readonly exerciseTitle?: string
   readonly author?: string | null
   readonly category: FeedbackCategoryValue
-  readonly message: string
+  readonly message?: string
 }

--- a/libs/feature/player/common/src/lib/feedback.model.ts
+++ b/libs/feature/player/common/src/lib/feedback.model.ts
@@ -31,7 +31,6 @@ export function getFeedbackCategoryLabel(value: FeedbackCategoryValue): string {
 export interface Feedback {
   readonly sessionId: string
   readonly exerciseTitle?: string
-  readonly author?: string | null
   readonly category: FeedbackCategoryValue
   readonly message?: string
 }

--- a/libs/feature/player/common/src/lib/feedback.model.ts
+++ b/libs/feature/player/common/src/lib/feedback.model.ts
@@ -1,0 +1,39 @@
+export enum FeedbackCategoryValue {
+  STATEMENT = 'statement',
+  ANSWER = 'answer',
+  ACCESSIBILITY = 'accessibility',
+  TECHNICAL = 'technical',
+  SUGGESTION = 'suggestion',
+  OTHER = 'other',
+}
+
+export const feedbackCategoryLabels: Record<FeedbackCategoryValue, string> = {
+  [FeedbackCategoryValue.STATEMENT]: "L'énoncé de l'exercice",
+  [FeedbackCategoryValue.ANSWER]: 'Les modalités de réponse',
+  [FeedbackCategoryValue.ACCESSIBILITY]: "L'accessibilité de l'exercice",
+  [FeedbackCategoryValue.TECHNICAL]: "Le fonctionnement de l'exercice",
+  [FeedbackCategoryValue.SUGGESTION]: 'Une suggestion d’amélioration',
+  [FeedbackCategoryValue.OTHER]: 'Autre chose',
+}
+
+export interface FeedbackCategory {
+  readonly value: FeedbackCategoryValue
+  readonly label: string
+}
+
+export const FEEDBACK_CATEGORIES: FeedbackCategory[] = Object.entries(feedbackCategoryLabels).map(([value, label]) => ({
+  value: value as FeedbackCategoryValue,
+  label: label,
+}))
+
+export function getFeedbackCategoryLabel(value: FeedbackCategoryValue): string {
+  return feedbackCategoryLabels[value]
+}
+
+export interface Feedback {
+  readonly sessionId: string
+  readonly exerciseTitle?: string
+  readonly author?: string | null
+  readonly category: FeedbackCategoryValue
+  readonly message: string
+}

--- a/libs/feature/player/server/src/lib/feedback/feedback.controller.spec.ts
+++ b/libs/feature/player/server/src/lib/feedback/feedback.controller.spec.ts
@@ -1,0 +1,61 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { IRequest } from '@platon/core/server'
+import { createUserEntity } from '@platon/core/testing/server'
+import { FeedbackCategoryValue } from '@platon/feature/player/common'
+import { FeedbackController } from './feedback.controller'
+import { FeedbackDTO } from './feedback.dto'
+import { FeedbackService } from './feedback.service'
+
+describe('FeedbackController', () => {
+  let controller: FeedbackController
+  let service: jest.Mocked<FeedbackService>
+
+  const mockUser = createUserEntity({ id: 'sender-test-id' })
+  const mockReq = { user: mockUser } as unknown as IRequest
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [FeedbackController],
+      providers: [
+        {
+          provide: FeedbackService,
+          useValue: {
+            submitFeedback: jest.fn(),
+          },
+        },
+      ],
+    }).compile()
+
+    controller = module.get(FeedbackController)
+    service = module.get(FeedbackService)
+  })
+
+  afterEach(() => jest.clearAllMocks())
+
+  describe('POST /player/feedback', () => {
+    it('should delegate to the service with the authenticated user id', async () => {
+      service.submitFeedback.mockResolvedValue(undefined)
+
+      const input: FeedbackDTO = {
+        sessionId: 'session-test-id',
+        exerciseTitle: 'Connaissez vous les drapeaux ?',
+        category: FeedbackCategoryValue.STATEMENT,
+        message: "L'énoncé n'est pas assez explicite.",
+      }
+      await controller.submitFeedback(mockReq, input)
+
+      expect(service.submitFeedback).toHaveBeenCalledWith(input, mockUser.id)
+    })
+
+    it('should propagate errors thrown by the service', async () => {
+      service.submitFeedback.mockRejectedValue(new Error('No creator found for session session-test-id.'))
+
+      const input: FeedbackDTO = {
+        sessionId: 'session-test-id',
+        category: FeedbackCategoryValue.OTHER,
+      }
+
+      await expect(controller.submitFeedback(mockReq, input)).rejects.toThrow('No creator found')
+    })
+  })
+})

--- a/libs/feature/player/server/src/lib/feedback/feedback.controller.ts
+++ b/libs/feature/player/server/src/lib/feedback/feedback.controller.ts
@@ -8,5 +8,7 @@ export class FeedbackController {
   constructor(private readonly feedbackService: FeedbackService) {}
 
   @Post()
-  async submitFeedback(@Req() req: IRequest, @Body() feedback: FeedbackDTO): Promise<void> {}
+  async submitFeedback(@Req() req: IRequest, @Body() feedback: FeedbackDTO): Promise<void> {
+    await this.feedbackService.submitFeedback(feedback, req.user.id)
+  }
 }

--- a/libs/feature/player/server/src/lib/feedback/feedback.controller.ts
+++ b/libs/feature/player/server/src/lib/feedback/feedback.controller.ts
@@ -1,0 +1,10 @@
+import { Controller, Post } from '@nestjs/common'
+import { FeedbackService } from './feedback.service'
+
+@Controller('player/feedback')
+export class FeedbackController {
+  constructor(private readonly feedbackService: FeedbackService) {}
+
+  @Post()
+  async submitFeedback(): Promise<void> {}
+}

--- a/libs/feature/player/server/src/lib/feedback/feedback.controller.ts
+++ b/libs/feature/player/server/src/lib/feedback/feedback.controller.ts
@@ -1,14 +1,20 @@
-import { Body, Controller, Post, Req } from '@nestjs/common'
+import { Body, Controller, Logger, Post, Req } from '@nestjs/common'
 import { FeedbackService } from './feedback.service'
-import { IRequest } from '@platon/core/server'
+import { IRequest, Roles } from '@platon/core/server'
 import { FeedbackDTO } from './feedback.dto'
+import { ApiBearerAuth, ApiTags } from '@nestjs/swagger'
 
+@ApiBearerAuth()
 @Controller('player/feedback')
+@ApiTags('Players')
 export class FeedbackController {
+  private readonly logger = new Logger(FeedbackController.name)
   constructor(private readonly feedbackService: FeedbackService) {}
 
   @Post()
+  @Roles('admin', 'teacher', 'student', 'candidate')
   async submitFeedback(@Req() req: IRequest, @Body() feedback: FeedbackDTO): Promise<void> {
     await this.feedbackService.submitFeedback(feedback, req.user.id)
+    this.logger.debug(`Feedback received from ${req.user.id} for session ${feedback.sessionId}.`)
   }
 }

--- a/libs/feature/player/server/src/lib/feedback/feedback.controller.ts
+++ b/libs/feature/player/server/src/lib/feedback/feedback.controller.ts
@@ -1,10 +1,12 @@
-import { Controller, Post } from '@nestjs/common'
+import { Body, Controller, Post, Req } from '@nestjs/common'
 import { FeedbackService } from './feedback.service'
+import { IRequest } from '@platon/core/server'
+import { FeedbackDTO } from './feedback.dto'
 
 @Controller('player/feedback')
 export class FeedbackController {
   constructor(private readonly feedbackService: FeedbackService) {}
 
   @Post()
-  async submitFeedback(): Promise<void> {}
+  async submitFeedback(@Req() req: IRequest, @Body() feedback: FeedbackDTO): Promise<void> {}
 }

--- a/libs/feature/player/server/src/lib/feedback/feedback.dto.ts
+++ b/libs/feature/player/server/src/lib/feedback/feedback.dto.ts
@@ -11,11 +11,6 @@ export class FeedbackDTO implements Feedback {
   @ApiProperty()
   exerciseTitle?: string
 
-  @IsString()
-  @ApiProperty()
-  @IsOptional()
-  author?: string | null
-
   @IsEnum(FeedbackCategoryValue)
   @ApiProperty({ enum: FeedbackCategoryValue })
   category!: FeedbackCategoryValue

--- a/libs/feature/player/server/src/lib/feedback/feedback.dto.ts
+++ b/libs/feature/player/server/src/lib/feedback/feedback.dto.ts
@@ -1,0 +1,27 @@
+import { ApiProperty } from '@nestjs/swagger'
+import { Feedback, FeedbackCategoryValue } from '@platon/feature/player/common'
+import { IsEnum, IsOptional, IsString, IsUUID } from 'class-validator'
+
+export class FeedbackDTO implements Feedback {
+  @IsUUID()
+  @ApiProperty()
+  sessionId!: string
+
+  @IsString()
+  @ApiProperty()
+  exerciseTitle?: string
+
+  @IsString()
+  @ApiProperty()
+  @IsOptional()
+  author?: string | null
+
+  @IsEnum(FeedbackCategoryValue)
+  @ApiProperty({ enum: FeedbackCategoryValue })
+  category!: FeedbackCategoryValue
+
+  @IsString()
+  @ApiProperty()
+  @IsOptional()
+  message?: string
+}

--- a/libs/feature/player/server/src/lib/feedback/feedback.entity.ts
+++ b/libs/feature/player/server/src/lib/feedback/feedback.entity.ts
@@ -1,0 +1,35 @@
+import { BaseEntity, UserEntity } from '@platon/core/server'
+import { Feedback, FeedbackCategoryValue } from '@platon/feature/player/common'
+import { SessionEntity } from '@platon/feature/result/server'
+import { Column, Entity, Index, JoinColumn, ManyToOne } from 'typeorm'
+
+@Entity('Feedbacks')
+export class FeedbackEntity extends BaseEntity implements Feedback {
+  @Index('Feedbacks_session_id_idx')
+  @Column({ name: 'session_id' })
+  sessionId!: string
+
+  @ManyToOne(() => SessionEntity, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'session_id' })
+  session!: SessionEntity
+
+  @Column({ name: 'exercise_title', nullable: true })
+  exerciseTitle?: string
+
+  @Column({ nullable: true })
+  author?: string | null
+
+  @Column({ type: 'enum', enum: FeedbackCategoryValue })
+  category!: FeedbackCategoryValue
+
+  @Column({ type: 'text', nullable: true })
+  message?: string
+
+  @Column({ name: 'sender_id', default: '00000000-0000-0000-0000-000000000000' })
+  senderId!: string
+
+  // @ts-expect-error: SET DEFAULT does not exist in OnDeleteType
+  @ManyToOne(() => UserEntity, { onDelete: 'SET DEFAULT' })
+  @JoinColumn({ name: 'sender_id' })
+  sender!: UserEntity
+}

--- a/libs/feature/player/server/src/lib/feedback/feedback.entity.ts
+++ b/libs/feature/player/server/src/lib/feedback/feedback.entity.ts
@@ -16,15 +16,6 @@ export class FeedbackEntity extends BaseEntity implements Feedback {
   @Column({ name: 'exercise_title', nullable: true })
   exerciseTitle?: string
 
-  @Column({ nullable: true })
-  author?: string | null
-
-  @Column({ type: 'enum', enum: FeedbackCategoryValue })
-  category!: FeedbackCategoryValue
-
-  @Column({ type: 'text', nullable: true })
-  message?: string
-
   @Column({ name: 'sender_id', default: '00000000-0000-0000-0000-000000000000' })
   senderId!: string
 
@@ -32,4 +23,13 @@ export class FeedbackEntity extends BaseEntity implements Feedback {
   @ManyToOne(() => UserEntity, { onDelete: 'SET DEFAULT' })
   @JoinColumn({ name: 'sender_id' })
   sender!: UserEntity
+
+  @Column({ name: 'creator_id', nullable: true })
+  creatorId?: string
+
+  @Column({ type: 'enum', enum: FeedbackCategoryValue })
+  category!: FeedbackCategoryValue
+
+  @Column({ type: 'text', nullable: true })
+  message?: string
 }

--- a/libs/feature/player/server/src/lib/feedback/feedback.service.integration.spec.ts
+++ b/libs/feature/player/server/src/lib/feedback/feedback.service.integration.spec.ts
@@ -1,0 +1,179 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { randomUUID } from 'crypto'
+import { DataSource, Repository } from 'typeorm'
+import { UserEntity } from '@platon/core/server'
+import { createTestDatabase, TestDatabase } from '@platon/core/testing/server'
+import { UserRoles } from '@platon/core/common'
+import { ActivityEntity, CourseEntity, CourseSectionEntity } from '@platon/feature/course/server'
+import { CorrectionEntity, SessionDataEntity, SessionEntity } from '@platon/feature/result/server'
+// Non exportée publiquement mais nécessaire car SessionEntity a une @OneToMany vers elle
+import { StudentSubmissionEntity } from '@platon/feature/result/server'
+import { ResourceTypes } from '@platon/feature/resource/common'
+import { FeedbackCategoryValue } from '@platon/feature/player/common'
+import { FeedbackEntity } from './feedback.entity'
+import { FeedbackService } from './feedback.service'
+
+describe('FeedbackService (integration)', () => {
+  let testDb: TestDatabase
+  let dataSource: DataSource
+  let userRepo: Repository<UserEntity>
+  let sessionRepo: Repository<SessionEntity>
+  let sessionDataRepo: Repository<SessionDataEntity>
+  let feedbackRepo: Repository<FeedbackEntity>
+  let service: FeedbackService
+
+  const emailService = {
+    send: jest.fn().mockResolvedValue(true),
+    sendToPlatonTeam: jest.fn().mockResolvedValue(true),
+  }
+
+  beforeAll(async () => {
+    testDb = await createTestDatabase([
+      UserEntity,
+      CourseEntity,
+      CourseSectionEntity,
+      ActivityEntity,
+      CorrectionEntity,
+      SessionEntity,
+      StudentSubmissionEntity,
+      SessionDataEntity,
+      FeedbackEntity,
+    ])
+    dataSource = testDb.dataSource
+    userRepo = dataSource.getRepository(UserEntity)
+    sessionRepo = dataSource.getRepository(SessionEntity)
+    sessionDataRepo = dataSource.getRepository(SessionDataEntity)
+    feedbackRepo = dataSource.getRepository(FeedbackEntity)
+
+    service = new FeedbackService(feedbackRepo, sessionRepo, emailService as any)
+  }, 60_000)
+
+  afterAll(async () => {
+    await testDb.teardown()
+  })
+
+  afterEach(async () => {
+    jest.clearAllMocks()
+    await dataSource.query('TRUNCATE "Feedbacks" CASCADE')
+    await dataSource.query('TRUNCATE "SessionData" CASCADE')
+    await dataSource.query('TRUNCATE "Sessions" CASCADE')
+    await dataSource.query('TRUNCATE "Users" CASCADE')
+  })
+
+  // ─── helpers ──────────────────────────────────────────────────────────────
+
+  const seedUser = async (overrides: Partial<UserEntity> = {}): Promise<UserEntity> => {
+    const suffix = Math.random().toString(36).slice(2)
+    return userRepo.save(
+      userRepo.create({
+        username: `feedback-integration-${suffix}`,
+        firstName: 'Test',
+        lastName: 'User',
+        email: `${suffix}@integration.test`,
+        role: UserRoles.teacher,
+        active: true,
+        lastActivity: new Date(),
+        ...overrides,
+      })
+    )
+  }
+
+  const seedSession = async (): Promise<SessionEntity> => {
+    return sessionRepo.save(
+      sessionRepo.create({
+        variables: {} as any,
+        grade: -1,
+        attempts: 0,
+        isBuilt: false,
+        source: {
+          abspath: '/test/exercise.ple',
+          variables: {} as any,
+          dependencies: [],
+        },
+      })
+    )
+  }
+
+  const seedSessionData = async (
+    sessionId: string,
+    overrides: Partial<SessionDataEntity> = {}
+  ): Promise<SessionDataEntity> => {
+    return sessionDataRepo.save(
+      sessionDataRepo.create({
+        id: sessionId,
+        grade: -1,
+        attempts: 0,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+        resourceId: randomUUID(),
+        resourceType: ResourceTypes.EXERCISE,
+        resourceName: 'Connaissez vous les drapeaux ?',
+        resourceOwnerId: '00000000-0000-0000-0000-000000000000',
+        resourceVersion: 'main',
+        circleId: randomUUID(),
+        circleName: 'Test Circle',
+        ...overrides,
+      })
+    )
+  }
+
+  // ─── submitFeedback ───────────────────────────────────────────────────────
+
+  it('should resolve the resource owner as creator for a standalone exercise (no activity)', async () => {
+    const sender = await seedUser({ role: UserRoles.student })
+    const creator = await seedUser({ role: UserRoles.teacher })
+    const session = await seedSession()
+    await seedSessionData(session.id, { resourceOwnerId: creator.id })
+
+    await service.submitFeedback(
+      {
+        sessionId: session.id,
+        exerciseTitle: 'Connaissez vous les drapeaux ?',
+        category: FeedbackCategoryValue.STATEMENT,
+        message: "L'énoncé n'est pas assez explicite.",
+      },
+      sender.id
+    )
+
+    expect(emailService.send).toHaveBeenCalledWith(expect.objectContaining({ to: creator.email }))
+    expect(emailService.sendToPlatonTeam).not.toHaveBeenCalled()
+
+    const saved = await feedbackRepo.findOne({ where: { sessionId: session.id } })
+    expect(saved?.creatorId).toBe(creator.id)
+    expect(saved?.senderId).toBe(sender.id)
+    expect(saved?.category).toBe(FeedbackCategoryValue.STATEMENT)
+  })
+
+  it('should prioritize the activity creator over the resource owner when both are set', async () => {
+    const sender = await seedUser({ role: UserRoles.student })
+    const resourceOwner = await seedUser({ role: UserRoles.teacher })
+    const activityCreator = await seedUser({ role: UserRoles.teacher })
+    const session = await seedSession()
+    await seedSessionData(session.id, {
+      resourceOwnerId: resourceOwner.id,
+      activityCreatorId: activityCreator.id,
+    })
+
+    await service.submitFeedback({ sessionId: session.id, category: FeedbackCategoryValue.TECHNICAL }, sender.id)
+
+    const saved = await feedbackRepo.findOne({ where: { sessionId: session.id } })
+    expect(saved?.creatorId).toBe(activityCreator.id)
+    expect(emailService.sendToPlatonTeam).toHaveBeenCalledTimes(1)
+    expect(emailService.send).not.toHaveBeenCalled()
+  })
+
+  it('should throw and persist nothing when the session has no related SessionData row', async () => {
+    const sender = await seedUser({ role: UserRoles.student })
+    const session = await seedSession()
+    // pas de seedSessionData ici : la session n'a aucune ligne SessionData associée
+
+    await expect(
+      service.submitFeedback({ sessionId: session.id, category: FeedbackCategoryValue.OTHER }, sender.id)
+    ).rejects.toThrow()
+
+    const count = await feedbackRepo.count({ where: { sessionId: session.id } })
+    expect(count).toBe(0)
+    expect(emailService.send).not.toHaveBeenCalled()
+    expect(emailService.sendToPlatonTeam).not.toHaveBeenCalled()
+  })
+})

--- a/libs/feature/player/server/src/lib/feedback/feedback.service.spec.ts
+++ b/libs/feature/player/server/src/lib/feedback/feedback.service.spec.ts
@@ -1,0 +1,110 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { getRepositoryToken } from '@nestjs/typeorm'
+import { EmailService } from '@platon/feature/email/server'
+import { FeedbackCategoryValue } from '@platon/feature/player/common'
+import { SessionEntity } from '@platon/feature/result/server'
+import { mockRepository, MockRepository } from '@platon/core/testing/server'
+import { FeedbackDTO } from './feedback.dto'
+import { FeedbackEntity } from './feedback.entity'
+import { FeedbackService } from './feedback.service'
+
+describe('FeedbackService', () => {
+  let service: FeedbackService
+  let feedbackRepository: MockRepository<FeedbackEntity>
+  let sessionRepository: { query: jest.Mock }
+  let emailService: jest.Mocked<Pick<EmailService, 'send' | 'sendToPlatonTeam'>>
+
+  const baseInput: FeedbackDTO = {
+    sessionId: 'session-test-id',
+    exerciseTitle: 'Connaissez vous les drapeaux ?',
+    category: FeedbackCategoryValue.STATEMENT,
+    message: "L'énoncé n'est pas assez explicite.",
+  }
+
+  const creatorRow = {
+    creatorId: 'creator-test-id',
+    firstName: 'Dominique',
+    lastName: 'Revuz',
+    email: 'dominique.revuz@univ-eiffel.fr',
+  }
+
+  beforeEach(async () => {
+    feedbackRepository = mockRepository<FeedbackEntity>()
+    feedbackRepository.create.mockImplementation((data) => data as FeedbackEntity)
+    sessionRepository = { query: jest.fn().mockResolvedValue([creatorRow]) }
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        FeedbackService,
+        { provide: getRepositoryToken(FeedbackEntity), useValue: feedbackRepository },
+        { provide: getRepositoryToken(SessionEntity), useValue: sessionRepository },
+        {
+          provide: EmailService,
+          useValue: {
+            send: jest.fn().mockResolvedValue(true),
+            sendToPlatonTeam: jest.fn().mockResolvedValue(true),
+          },
+        },
+      ],
+    }).compile()
+
+    service = module.get(FeedbackService)
+    emailService = module.get(EmailService)
+  })
+
+  afterEach(() => jest.clearAllMocks())
+
+  it('should throw when no creator can be resolved for the session', async () => {
+    sessionRepository.query.mockResolvedValue([])
+
+    await expect(service.submitFeedback(baseInput, 'sender-test-id')).rejects.toThrow()
+    expect(feedbackRepository.save).not.toHaveBeenCalled()
+    expect(emailService.send).not.toHaveBeenCalled()
+    expect(emailService.sendToPlatonTeam).not.toHaveBeenCalled()
+  })
+
+  it('should attach the resolved creatorId and the senderId to the persisted entity', async () => {
+    await service.submitFeedback(baseInput, 'sender-test-id')
+
+    expect(feedbackRepository.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionId: baseInput.sessionId,
+        category: baseInput.category,
+        creatorId: creatorRow.creatorId,
+        senderId: 'sender-test-id',
+      })
+    )
+    expect(feedbackRepository.save).toHaveBeenCalledTimes(1)
+  })
+
+  it.each([
+    [FeedbackCategoryValue.STATEMENT, true, false],
+    [FeedbackCategoryValue.ANSWER, true, false],
+    [FeedbackCategoryValue.ACCESSIBILITY, true, true],
+    [FeedbackCategoryValue.TECHNICAL, false, true],
+    [FeedbackCategoryValue.OTHER, false, true],
+  ])('category %s should notify creator=%s and PLaTOn team=%s', async (category, notifiesCreator, notifiesTeam) => {
+    await service.submitFeedback({ ...baseInput, category }, 'sender-test-id')
+
+    if (notifiesCreator) {
+      expect(emailService.send).toHaveBeenCalledWith(expect.objectContaining({ to: creatorRow.email }))
+    } else {
+      expect(emailService.send).not.toHaveBeenCalled()
+    }
+
+    if (notifiesTeam) {
+      expect(emailService.sendToPlatonTeam).toHaveBeenCalled()
+    } else {
+      expect(emailService.sendToPlatonTeam).not.toHaveBeenCalled()
+    }
+  })
+
+  it('should still persist the feedback even when every notification fails to send', async () => {
+    emailService.send.mockResolvedValue(false)
+    emailService.sendToPlatonTeam.mockResolvedValue(false)
+
+    await service.submitFeedback({ ...baseInput, category: FeedbackCategoryValue.ACCESSIBILITY }, 'sender-test-id')
+
+    expect(feedbackRepository.save).toHaveBeenCalledTimes(1)
+  })
+})

--- a/libs/feature/player/server/src/lib/feedback/feedback.service.ts
+++ b/libs/feature/player/server/src/lib/feedback/feedback.service.ts
@@ -1,7 +1,47 @@
-import { Injectable } from '@nestjs/common'
+import { Injectable, Logger } from '@nestjs/common'
+import { InjectRepository } from '@nestjs/typeorm'
 import { EmailService } from '@platon/feature/email/server'
+import { FeedbackEntity } from './feedback.entity'
+import { Repository } from 'typeorm'
+import { FeedbackDTO } from './feedback.dto'
+import { UserService } from '@platon/core/server'
+import { SessionEntity } from '@platon/feature/result/server'
+
+type projection = {
+  creatorId: string
+  firstName: string
+  lastName: string
+  email: string
+}
 
 @Injectable()
 export class FeedbackService {
-  constructor(private readonly emailService: EmailService) {}
+  private readonly logger = new Logger(FeedbackService.name)
+
+  constructor(
+    @InjectRepository(FeedbackEntity) private readonly feedbackRepository: Repository<FeedbackEntity>,
+    @InjectRepository(SessionEntity)
+    private readonly sessionRepository: Repository<SessionEntity>,
+    private readonly emailService: EmailService,
+    private readonly userService: UserService
+  ) {}
+
+  async submitFeedback(input: FeedbackDTO, senderId: string): Promise<void> {
+    const queryText = `SELECT users.id AS "creatorId", first_name AS "firstName", last_name AS "lastName", email
+      FROM Sessions sessions
+      INNER JOIN Activities activities ON sessions.activity_id = activities.id
+      INNER JOIN Users users ON activities.creator_id = users.id
+      WHERE sessions.id = $1
+    `
+    const creator: projection = await this.sessionRepository.query(queryText, [input.sessionId])
+    const feedbackEntity = this.feedbackRepository.create({
+      ...input,
+      creatorId: creator.creatorId,
+      senderId: senderId,
+    })
+    this.logger.log(
+      `Feedback received from ${feedbackEntity.senderId} for session ${feedbackEntity.sessionId}. Sending email to ${creator.email}`
+    )
+    // await this.feedbackRepository.save(feedbackEntity)
+  }
 }

--- a/libs/feature/player/server/src/lib/feedback/feedback.service.ts
+++ b/libs/feature/player/server/src/lib/feedback/feedback.service.ts
@@ -1,0 +1,7 @@
+import { Injectable } from '@nestjs/common'
+import { EmailService } from '@platon/feature/email/server'
+
+@Injectable()
+export class FeedbackService {
+  constructor(private readonly emailService: EmailService) {}
+}

--- a/libs/feature/player/server/src/lib/feedback/feedback.service.ts
+++ b/libs/feature/player/server/src/lib/feedback/feedback.service.ts
@@ -1,10 +1,10 @@
 import { Injectable, Logger } from '@nestjs/common'
 import { InjectRepository } from '@nestjs/typeorm'
 import { EmailService } from '@platon/feature/email/server'
+import { FeedbackCategoryValue, getFeedbackCategoryLabel } from '@platon/feature/player/common'
 import { FeedbackEntity } from './feedback.entity'
 import { Repository } from 'typeorm'
 import { FeedbackDTO } from './feedback.dto'
-import { UserService } from '@platon/core/server'
 import { SessionEntity } from '@platon/feature/result/server'
 
 type projection = {
@@ -12,6 +12,22 @@ type projection = {
   firstName: string
   lastName: string
   email: string
+}
+
+enum FeedbackRecipient {
+  CREATOR = 'creator',
+  PLATON_TEAM = 'platon_team',
+}
+
+// Détermine qui doit être notifié selon la nature du problème signalé :
+// le créateur de l'activité/exercice peut seul corriger le contenu, l'équipe PLaTOn
+// gère ce qui relève de la plateforme. L'accessibilité peut relever des deux.
+const FEEDBACK_RECIPIENTS: Record<FeedbackCategoryValue, FeedbackRecipient[]> = {
+  [FeedbackCategoryValue.STATEMENT]: [FeedbackRecipient.CREATOR],
+  [FeedbackCategoryValue.ANSWER]: [FeedbackRecipient.CREATOR],
+  [FeedbackCategoryValue.ACCESSIBILITY]: [FeedbackRecipient.CREATOR, FeedbackRecipient.PLATON_TEAM],
+  [FeedbackCategoryValue.TECHNICAL]: [FeedbackRecipient.PLATON_TEAM],
+  [FeedbackCategoryValue.OTHER]: [FeedbackRecipient.PLATON_TEAM],
 }
 
 @Injectable()
@@ -22,26 +38,60 @@ export class FeedbackService {
     @InjectRepository(FeedbackEntity) private readonly feedbackRepository: Repository<FeedbackEntity>,
     @InjectRepository(SessionEntity)
     private readonly sessionRepository: Repository<SessionEntity>,
-    private readonly emailService: EmailService,
-    private readonly userService: UserService
+    private readonly emailService: EmailService
   ) {}
 
   async submitFeedback(input: FeedbackDTO, senderId: string): Promise<void> {
-    const queryText = `SELECT users.id AS "creatorId", first_name AS "firstName", last_name AS "lastName", email
-      FROM Sessions sessions
-      INNER JOIN Activities activities ON sessions.activity_id = activities.id
-      INNER JOIN Users users ON activities.creator_id = users.id
-      WHERE sessions.id = $1
-    `
-    const creator: projection = await this.sessionRepository.query(queryText, [input.sessionId])
+    const queryText = `
+    SELECT
+      COALESCE(session_data.activity_creator_id, session_data.resource_owner_id, session_data.course_owner_id) AS "creatorId",
+      users.first_name AS "firstName",
+      users.last_name AS "lastName",
+      users.email
+    FROM "SessionData" session_data
+    INNER JOIN "Users" users
+      ON users.id = COALESCE(session_data.activity_creator_id, session_data.resource_owner_id, session_data.course_owner_id)
+    WHERE session_data.id = $1
+  `
+    const [resourceCreator]: projection[] = await this.sessionRepository.query(queryText, [input.sessionId])
+
+    if (!resourceCreator) {
+      this.logger.error(
+        `No creator found for session ${input.sessionId} since activity is not found or creator is not found.`
+      )
+      throw new Error(`No creator found for session ${input.sessionId}.`)
+    }
     const feedbackEntity = this.feedbackRepository.create({
       ...input,
-      creatorId: creator.creatorId,
+      creatorId: resourceCreator.creatorId,
       senderId: senderId,
     })
+
+    const categoryLabel = getFeedbackCategoryLabel(input.category)
+    const subject = `[Signalement PLaTOn] ${input.exerciseTitle ?? 'Exercice'} - ${categoryLabel}`
+    const content = [
+      'Un signalement a été soumis sur PLaTOn.',
+      '',
+      `Exercice : ${input.exerciseTitle ?? 'N/A'}`,
+      `Catégorie : ${categoryLabel}`,
+      'Message :',
+      input.message ?? '(aucun message)',
+    ].join('\n')
+
+    const recipients = FEEDBACK_RECIPIENTS[input.category]
+
+    if (recipients.includes(FeedbackRecipient.CREATOR)) {
+      await this.emailService.send({ to: resourceCreator.email, subject, text: content })
+    }
+    if (recipients.includes(FeedbackRecipient.PLATON_TEAM)) {
+      await this.emailService.sendToPlatonTeam({ subject, text: content })
+    }
+
+    await this.feedbackRepository.save(feedbackEntity)
+
+    const notified = recipients.join(', ')
     this.logger.log(
-      `Feedback received from ${feedbackEntity.senderId} for session ${feedbackEntity.sessionId}. Sending email to ${creator.email}`
+      `Feedback from ${senderId} for session ${input.sessionId} (${input.category}): notified ${notified}.`
     )
-    // await this.feedbackRepository.save(feedbackEntity)
   }
 }

--- a/libs/feature/player/server/src/lib/player.module.ts
+++ b/libs/feature/player/server/src/lib/player.module.ts
@@ -11,9 +11,14 @@ import { NodeSandbox } from './sandboxes'
 import { PythonSandbox } from './sandboxes/python/python-sandbox'
 import { SandboxService } from './sandboxes/sandbox.service'
 import { FeatureEmailModule } from '@platon/feature/email/server'
+import { FeedbackController } from './feedback/feedback.controller'
+import { FeedbackService } from './feedback/feedback.service'
+import { FeedbackEntity } from './feedback/feedback.entity'
+import { TypeOrmModule } from '@nestjs/typeorm'
+import { UserModule } from '@platon/core/server'
 
 @Module({
-  controllers: [PlayerController],
+  controllers: [PlayerController, FeedbackController],
   imports: [
     HttpModule,
     DiscoveryModule,
@@ -22,8 +27,10 @@ import { FeatureEmailModule } from '@platon/feature/email/server'
     FeatureResourceServerModule,
     FeaturePeerServerModule,
     FeatureEmailModule,
+    UserModule,
+    TypeOrmModule.forFeature([FeedbackEntity]),
   ],
-  providers: [PlayerService, NodeSandbox, PythonSandbox, SandboxService],
+  providers: [PlayerService, NodeSandbox, PythonSandbox, SandboxService, FeedbackService],
   exports: [PlayerService, SandboxService],
 })
 export class FeaturePlayerServerModule {}

--- a/migrations/1782382356642-FeedbackEntity.ts
+++ b/migrations/1782382356642-FeedbackEntity.ts
@@ -1,0 +1,26 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class FeedbackEntity1782382356642 implements MigrationInterface {
+    name = 'FeedbackEntity1782382356642'
+
+    public async up(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`CREATE TYPE "public"."Feedbacks_category_enum" AS ENUM('statement', 'answer', 'accessibility', 'technical', 'other')`);
+        await queryRunner.query(`CREATE TABLE "Feedbacks" ("id" uuid NOT NULL DEFAULT uuid_generate_v4(), "created_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "updated_at" TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT now(), "session_id" uuid NOT NULL, "exercise_title" character varying, "sender_id" uuid NOT NULL DEFAULT '00000000-0000-0000-0000-000000000000', "creator_id" character varying, "category" "public"."Feedbacks_category_enum" NOT NULL, "message" text, CONSTRAINT "PK_2a57575bac40d1a302ef02a8530" PRIMARY KEY ("id"))`);
+        await queryRunner.query(`CREATE INDEX "IDX_c6763f25b8c60b0eaff080a0a9" ON "Feedbacks" ("created_at") `);
+        await queryRunner.query(`CREATE INDEX "IDX_89a218cec414e2b44e78558c98" ON "Feedbacks" ("updated_at") `);
+        await queryRunner.query(`CREATE INDEX "Feedbacks_session_id_idx" ON "Feedbacks" ("session_id") `);
+        await queryRunner.query(`ALTER TABLE "Feedbacks" ADD CONSTRAINT "FK_ab01e33f15da34b0b6108e8b7c2" FOREIGN KEY ("session_id") REFERENCES "Sessions"("id") ON DELETE CASCADE ON UPDATE NO ACTION`);
+        await queryRunner.query(`ALTER TABLE "Feedbacks" ADD CONSTRAINT "FK_0b1fd9ba79d3ddc3ea15db71d13" FOREIGN KEY ("sender_id") REFERENCES "Users"("id") ON DELETE SET DEFAULT ON UPDATE NO ACTION`);
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<void> {
+        await queryRunner.query(`ALTER TABLE "Feedbacks" DROP CONSTRAINT "FK_0b1fd9ba79d3ddc3ea15db71d13"`);
+        await queryRunner.query(`ALTER TABLE "Feedbacks" DROP CONSTRAINT "FK_ab01e33f15da34b0b6108e8b7c2"`);
+        await queryRunner.query(`DROP INDEX "public"."Feedbacks_session_id_idx"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_89a218cec414e2b44e78558c98"`);
+        await queryRunner.query(`DROP INDEX "public"."IDX_c6763f25b8c60b0eaff080a0a9"`);
+        await queryRunner.query(`DROP TABLE "Feedbacks"`);
+        await queryRunner.query(`DROP TYPE "public"."Feedbacks_category_enum"`);
+    }
+
+}


### PR DESCRIPTION
This pull request introduces a user-facing feedback feature for reporting issues with exercises, as well as enhancements to the activity security warning system and minor UI improvements. The most significant changes are the addition of a feedback component allowing users to signal problems with exercises, and a visual warning/overlay when users attempt to leave a secured activity. There are also updates to email services and some internal refactoring.

**New exercise feedback feature:**

* Added the `PlayerQuestionFeedbackComponent` with UI, logic, and tests, allowing users to report exercise issues directly from the player interface. This includes category selection, message input, submission handling, and success feedback. (`player-question-feedback.component.html`, `player-question-feedback.component.ts`, `player-question-feedback.component.scss`, `player-question-feedback.component.spec.ts`) [[1]](diffhunk://#diff-7420b3b00c7420a39918f30dc3e875fd28710267ad3e8fe542d9fcdf1ff58316R1-R48) [[2]](diffhunk://#diff-8815d2d6ba9bbb8a31ed04249834e5aeb05ff1d13606e55b7302ab9a41dce8aaR1-R97) [[3]](diffhunk://#diff-832c9f372f606dc01f9759aeebdb352d60e4eb665c68915195fae5489cec7936R1-R103)
* Integrated the feedback component into the exercise view, displaying it when a user and player are present. (`player-exercise.component.html`, `player-exercise.component.ts`, `player-exercise.component.scss`) [[1]](diffhunk://#diff-eefcf7032df853236733f8e326c70ae8a54665cdca5c88307b552f197429f7bcR188-R194) [[2]](diffhunk://#diff-c17dd9122515544823d41db5367bf64a8300d6dc6352399a5a0f6732c7557fc7R57) [[3]](diffhunk://#diff-c17dd9122515544823d41db5367bf64a8300d6dc6352399a5a0f6732c7557fc7R120) [[4]](diffhunk://#diff-c17dd9122515544823d41db5367bf64a8300d6dc6352399a5a0f6732c7557fc7L134-R136) [[5]](diffhunk://#diff-a92d04ca8ac3a1aca8cdd6a6b03a9d74fc9eb358df656cf1997713d0324f0224R130-R131)

**Activity security and warning improvements:**

* Enhanced the activity player to visually warn users (banner and overlay) when they attempt to leave a secured activity, using pointer events, visibility changes, and beforeunload events. (`player-activity.component.ts`, `player-activity.component.html`, `player-activity.component.scss`) [[1]](diffhunk://#diff-12e889d4724efbc96b8d5813213138cc70ce56303479e355a8aa63813628efb5R119-R124) [[2]](diffhunk://#diff-12e889d4724efbc96b8d5813213138cc70ce56303479e355a8aa63813628efb5R328) [[3]](diffhunk://#diff-12e889d4724efbc96b8d5813213138cc70ce56303479e355a8aa63813628efb5R625-R652) [[4]](diffhunk://#diff-12e889d4724efbc96b8d5813213138cc70ce56303479e355a8aa63813628efb5R673-R684) [[5]](diffhunk://#diff-e314d3dbc9ac2fc81574d2b1d7bd921f02b1a23f557d5b7c2f07afa3d2083642R125-R133) [[6]](diffhunk://#diff-e314d3dbc9ac2fc81574d2b1d7bd921f02b1a23f557d5b7c2f07afa3d2083642R161-R167) [[7]](diffhunk://#diff-d2fe98797d94fa07dad915f9b98d0627613975a7f1d9e2663bd7c72aa6e826c9R355-R408)

**Backend and API changes:**

* Added a new method `submitFeedback` to the `PlayerService` and included the `Feedback` type in the public API, enabling feedback submission from the frontend. (`player.service.ts`) [[1]](diffhunk://#diff-c718bb5923cf27a946352ef008b34ff95b7322544a6b057dd16430aff144834dR14) [[2]](diffhunk://#diff-c718bb5923cf27a946352ef008b34ff95b7322544a6b057dd16430aff144834dR58-R61)

**Email service update:**

* Introduced `sendToPlatonTeam` in the `EmailService`, allowing emails to be sent to the PLaTOn team without technical alert deduplication/throttling. (`email.service.ts`)

**UI/UX refinements:**

* Improved the exercise actions layout for better responsiveness and ensured the "Save Answer" action is only present outside preview mode. (`player-exercise.component.ts`, `player-exercise.component.scss`) [[1]](diffhunk://#diff-c17dd9122515544823d41db5367bf64a8300d6dc6352399a5a0f6732c7557fc7L134-R136) [[2]](diffhunk://#diff-c17dd9122515544823d41db5367bf64a8300d6dc6352399a5a0f6732c7557fc7R189-R204) [[3]](diffhunk://#diff-c17dd9122515544823d41db5367bf64a8300d6dc6352399a5a0f6732c7557fc7L210-R228) [[4]](diffhunk://#diff-a92d04ca8ac3a1aca8cdd6a6b03a9d74fc9eb358df656cf1997713d0324f0224R130-R131)