### PR TITLE
Test/coverage resource server

### DIFF
--- a/libs/core/testing/server/src/lib/database/test-database.ts
+++ b/libs/core/testing/server/src/lib/database/test-database.ts
@@ -15,8 +15,13 @@ export interface TestDatabase {
  * Appeler `teardown()` dans `afterAll` pour nettoyer.
  *
  * @param entities - Liste des entités TypeORM à synchroniser dans la base de test
+ * @param setupSql - Instructions SQL brutes à exécuter après la synchronisation du schéma (ex: extensions,
+ *   fonctions ou vues matérialisées définies par migration, absentes du `synchronize: true`)
  */
-export const createTestDatabase = async (entities: EntityTarget<ObjectLiteral>[]): Promise<TestDatabase> => {
+export const createTestDatabase = async (
+  entities: EntityTarget<ObjectLiteral>[],
+  setupSql: string[] = []
+): Promise<TestDatabase> => {
   const container = await new PostgreSqlContainer('postgres:16-alpine')
     .withDatabase('platon_test')
     .withUsername('test')
@@ -38,6 +43,10 @@ export const createTestDatabase = async (entities: EntityTarget<ObjectLiteral>[]
   })
 
   await dataSource.initialize()
+
+  for (const sql of setupSql) {
+    await dataSource.query(sql)
+  }
 
   const teardown = async () => {
     await dataSource.destroy()

--- a/libs/core/testing/server/src/lib/mocks/query-builder.mock.ts
+++ b/libs/core/testing/server/src/lib/mocks/query-builder.mock.ts
@@ -17,8 +17,10 @@ export const mockSelectQueryBuilder = <T extends ObjectLiteral>() => {
     limit: jest.fn().mockReturnThis(),
     take: jest.fn().mockReturnThis(),
     skip: jest.fn().mockReturnThis(),
+    distinct: jest.fn().mockReturnThis(),
     getMany: jest.fn(),
     getOne: jest.fn(),
+    getOneOrFail: jest.fn(),
     getCount: jest.fn(),
     getManyAndCount: jest.fn().mockResolvedValue([[], 0] as [T[], number]),
   }

--- a/libs/core/testing/server/src/lib/mocks/repository.mock.ts
+++ b/libs/core/testing/server/src/lib/mocks/repository.mock.ts
@@ -10,6 +10,7 @@ export type MockRepository<T extends ObjectLiteral = ObjectLiteral> = jest.Mocke
     | 'find'
     | 'findOne'
     | 'findOneBy'
+    | 'findOneOrFail'
     | 'findAndCount'
     | 'save'
     | 'create'
@@ -25,6 +26,7 @@ export const mockRepository = <T extends ObjectLiteral>(): MockRepository<T> => 
   find: jest.fn(),
   findOne: jest.fn(),
   findOneBy: jest.fn(),
+  findOneOrFail: jest.fn(),
   findAndCount: jest.fn(),
   save: jest.fn(),
   create: jest.fn(),

--- a/libs/core/testing/server/src/lib/mocks/repository.mock.ts
+++ b/libs/core/testing/server/src/lib/mocks/repository.mock.ts
@@ -8,6 +8,7 @@ export type MockRepository<T extends ObjectLiteral = ObjectLiteral> = jest.Mocke
   Pick<
     Repository<T>,
     | 'find'
+    | 'findBy'
     | 'findOne'
     | 'findOneBy'
     | 'findOneOrFail'
@@ -24,6 +25,7 @@ export type MockRepository<T extends ObjectLiteral = ObjectLiteral> = jest.Mocke
 
 export const mockRepository = <T extends ObjectLiteral>(): MockRepository<T> => ({
   find: jest.fn(),
+  findBy: jest.fn(),
   findOne: jest.fn(),
   findOneBy: jest.fn(),
   findOneOrFail: jest.fn(),

--- a/libs/feature/resource/server/jest.config.ts
+++ b/libs/feature/resource/server/jest.config.ts
@@ -1,6 +1,7 @@
 module.exports = {
   displayName: 'feature-resource-server',
   preset: '../../../../jest.preset.js',
+  testPathIgnorePatterns: ['/node_modules/', '\\.integration\\.spec\\.ts$', '\\.e2e\\.spec\\.ts$'],
   testEnvironment: 'node',
   transform: {
     '^.+\\.ts$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],

--- a/libs/feature/resource/server/jest.integration.config.ts
+++ b/libs/feature/resource/server/jest.integration.config.ts
@@ -1,0 +1,18 @@
+export default {
+  displayName: 'feature-resource-server-integration',
+  preset: '../../../../jest.preset.js',
+  testMatch: ['**/*.integration.spec.ts'],
+  testTimeout: 60_000,
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.ts$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.integration.json' }],
+    '^.+\\.js$': [
+      '@swc/jest',
+      {
+        jsc: { target: 'es2022', parser: { syntax: 'ecmascript' } },
+        module: { type: 'commonjs' },
+      },
+    ],
+  },
+  coverageDirectory: '../../../../coverage/libs/feature/resource/server/integration',
+}

--- a/libs/feature/resource/server/project.json
+++ b/libs/feature/resource/server/project.json
@@ -14,6 +14,21 @@
       "options": {
         "jestConfig": "libs/feature/resource/server/jest.config.ts"
       }
+    },
+    "test:integration": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}/integration"],
+      "options": {
+        "jestConfig": "libs/feature/resource/server/jest.integration.config.ts",
+        "passWithNoTests": false
+      }
+    },
+    "test:all": {
+      "executor": "nx:run-commands",
+      "options": {
+        "commands": ["nx run feature-resource-server:test", "nx run feature-resource-server:test:integration"],
+        "parallel": false
+      }
     }
   }
 }

--- a/libs/feature/resource/server/src/lib/dependency/dependency.service.spec.ts
+++ b/libs/feature/resource/server/src/lib/dependency/dependency.service.spec.ts
@@ -1,0 +1,238 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { getRepositoryToken } from '@nestjs/typeorm'
+import { LATEST } from '@platon/feature/resource/common'
+import { MockRepository, mockRepository } from '@platon/core/testing/server'
+import { EntityManager } from 'typeorm'
+import { ResourceDependencyEntity } from './dependency.entity'
+import { ResourceDependencyService } from './dependency.service'
+
+describe('ResourceDependencyService', () => {
+  let service: ResourceDependencyService
+  let repository: MockRepository<ResourceDependencyEntity>
+
+  const buildInput = (overrides: Record<string, unknown> = {}) => ({
+    resourceId: 'resource-1',
+    dependOnId: 'depend-1',
+    resourceVersion: 'v1',
+    dependOnVersion: 'v1',
+    isTemplate: false,
+    ...overrides,
+  })
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ResourceDependencyService,
+        { provide: getRepositoryToken(ResourceDependencyEntity), useValue: mockRepository<ResourceDependencyEntity>() },
+      ],
+    }).compile()
+
+    service = module.get(ResourceDependencyService)
+    repository = module.get(getRepositoryToken(ResourceDependencyEntity))
+  })
+
+  describe('upsert', () => {
+    it('devrait créer une nouvelle dépendance si aucune existante', async () => {
+      repository.findOne.mockResolvedValue(null)
+      const created = { resourceId: 'resource-1', dependOnId: 'depend-1' } as ResourceDependencyEntity
+      repository.create.mockReturnValue(created)
+      repository.save.mockImplementation(async (d) => d as ResourceDependencyEntity)
+
+      const input = buildInput()
+      const result = await service.upsert(input)
+
+      expect(repository.create).toHaveBeenCalledWith(input)
+      expect(result.resourceVersion).toBe('v1')
+    })
+
+    it('devrait mettre à jour la dépendance existante plutôt que de la recréer', async () => {
+      const existing = {
+        resourceId: 'resource-1',
+        dependOnId: 'depend-1',
+        resourceVersion: 'old',
+      } as ResourceDependencyEntity
+      repository.findOne.mockResolvedValue(existing)
+      repository.save.mockImplementation(async (d) => d as ResourceDependencyEntity)
+
+      const result = await service.upsert(buildInput({ resourceVersion: 'v2' }))
+
+      expect(repository.create).not.toHaveBeenCalled()
+      expect(result.resourceVersion).toBe('v2')
+    })
+
+    it("devrait utiliser l'EntityManager fourni plutôt que le repository", async () => {
+      const entityManager = {
+        findOne: jest.fn().mockResolvedValue(null),
+        save: jest.fn().mockImplementation(async (_entity, d) => d),
+      } as unknown as EntityManager
+      // create() n'a pas besoin de l'EntityManager (ne touche pas la DB), le service l'appelle toujours sur le repository
+      repository.create.mockReturnValue({} as ResourceDependencyEntity)
+
+      await service.upsert(buildInput(), entityManager)
+
+      expect(entityManager.findOne).toHaveBeenCalled()
+      expect(entityManager.save).toHaveBeenCalled()
+      expect(repository.findOne).not.toHaveBeenCalled()
+      expect(repository.save).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('updateTemplateDependency', () => {
+    it('devrait forcer isTemplate=true', async () => {
+      repository.findOne.mockResolvedValue(null)
+      repository.create.mockReturnValue({} as ResourceDependencyEntity)
+      repository.save.mockImplementation(async (d) => d as ResourceDependencyEntity)
+
+      const result = await service.updateTemplateDependency(buildInput({ isTemplate: false }))
+
+      expect(repository.findOne).toHaveBeenCalledWith({
+        where: { resourceId: 'resource-1', resourceVersion: 'v1', isTemplate: true },
+      })
+      expect(result.isTemplate).toBe(true)
+    })
+  })
+
+  describe('createDependencyForNewVersion', () => {
+    it("devrait lever une erreur si aucune dépendance LATEST n'existe", async () => {
+      repository.findOne.mockResolvedValue(null)
+
+      await expect(service.createDependencyForNewVersion('resource-1', 'v2')).rejects.toThrow()
+    })
+
+    it('devrait retourner directement la dépendance LATEST si la version demandée est LATEST', async () => {
+      const latest = { resourceId: 'resource-1', resourceVersion: LATEST } as ResourceDependencyEntity
+      repository.findOne.mockResolvedValue(latest)
+
+      const result = await service.createDependencyForNewVersion('resource-1', LATEST)
+
+      expect(repository.create).not.toHaveBeenCalled()
+      expect(result).toBe(latest)
+    })
+
+    it('devrait créer une nouvelle dépendance copiant la cible de la version LATEST', async () => {
+      const latest = {
+        resourceId: 'resource-1',
+        dependOnId: 'depend-1',
+        dependOnVersion: 'v1',
+      } as ResourceDependencyEntity
+      repository.findOne.mockResolvedValue(latest)
+      const created = { resourceId: 'resource-1', resourceVersion: 'v2' } as ResourceDependencyEntity
+      repository.create.mockReturnValue(created)
+      repository.save.mockResolvedValue(created)
+
+      const result = await service.createDependencyForNewVersion('resource-1', 'v2')
+
+      expect(repository.create).toHaveBeenCalledWith(
+        expect.objectContaining({ resourceVersion: 'v2', dependOnId: 'depend-1', dependOnVersion: 'v1' })
+      )
+      expect(result).toBe(created)
+    })
+  })
+
+  describe('deleteDependencyForVersion', () => {
+    it('devrait supprimer par resourceId et resourceVersion', async () => {
+      await service.deleteDependencyForVersion('resource-1', 'v1')
+
+      expect(repository.delete).toHaveBeenCalledWith({ resourceId: 'resource-1', resourceVersion: 'v1' })
+    })
+  })
+
+  describe('delete', () => {
+    it('devrait supprimer via le repository sans EntityManager', async () => {
+      await service.delete('resource-1', 'depend-1')
+
+      expect(repository.delete).toHaveBeenCalledWith({ resourceId: 'resource-1', dependOnId: 'depend-1' })
+    })
+
+    it("devrait supprimer via l'EntityManager fourni", async () => {
+      const entityManager = { delete: jest.fn() } as unknown as EntityManager
+
+      await service.delete('resource-1', 'depend-1', entityManager)
+
+      expect(entityManager.delete).toHaveBeenCalledWith(ResourceDependencyEntity, {
+        resourceId: 'resource-1',
+        dependOnId: 'depend-1',
+      })
+      expect(repository.delete).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('fromActivity', () => {
+    it('devrait supprimer les dépendances absentes des groupes fournis et créer les nouvelles', async () => {
+      const obsolete = {
+        resourceId: 'act-1',
+        dependOnId: 'old-exercise',
+        resourceVersion: 'v1',
+      } as ResourceDependencyEntity
+      repository.find.mockResolvedValue([obsolete])
+      repository.findOne.mockResolvedValue(null)
+      repository.create.mockImplementation((d) => d as ResourceDependencyEntity)
+      repository.save.mockImplementation(async (d) => d as ResourceDependencyEntity)
+
+      const result = await service.fromActivity({
+        id: 'act-1',
+        version: 'v1',
+        exerciseGroups: {
+          group1: { exercises: [{ resource: 'new-exercise', version: 'v1' }] },
+        } as never,
+      })
+
+      expect(repository.delete).toHaveBeenCalledWith({ resourceId: 'act-1', dependOnId: 'old-exercise' })
+      expect(result).toHaveLength(1)
+      expect(result[0]).toMatchObject({ resourceId: 'act-1', dependOnId: 'new-exercise' })
+    })
+
+    it('ne devrait ni supprimer ni recréer une dépendance déjà présente dans les deux ensembles', async () => {
+      const existing = {
+        resourceId: 'act-1',
+        dependOnId: 'exercise-1',
+        resourceVersion: 'v1',
+      } as ResourceDependencyEntity
+      repository.find.mockResolvedValue([existing])
+
+      const result = await service.fromActivity({
+        id: 'act-1',
+        version: 'v1',
+        exerciseGroups: {
+          group1: { exercises: [{ resource: 'exercise-1', version: 'v1' }] },
+        } as never,
+      })
+
+      expect(repository.delete).not.toHaveBeenCalled()
+      expect(result).toHaveLength(0)
+    })
+  })
+
+  describe('listDependencies / listDependents / getTemplateDependency', () => {
+    it('devrait lister les dépendances avec les relations resource/dependOn', async () => {
+      repository.find.mockResolvedValue([])
+
+      await service.listDependencies('resource-1')
+
+      expect(repository.find).toHaveBeenCalledWith({
+        where: { resourceId: 'resource-1' },
+        relations: { resource: true, dependOn: true },
+      })
+    })
+
+    it('devrait lister les dépendants avec les relations resource/dependOn', async () => {
+      repository.find.mockResolvedValue([])
+
+      await service.listDependents('depend-1')
+
+      expect(repository.find).toHaveBeenCalledWith({
+        where: { dependOnId: 'depend-1' },
+        relations: { resource: true, dependOn: true },
+      })
+    })
+
+    it('devrait retourner la dépendance de template correspondante', async () => {
+      const dependency = { resourceId: 'resource-1' } as ResourceDependencyEntity
+      repository.findOne.mockResolvedValue(dependency)
+
+      const result = await service.getTemplateDependency('resource-1', 'v1')
+
+      expect(result).toBe(dependency)
+    })
+  })
+})

--- a/libs/feature/resource/server/src/lib/events/event.controller.spec.ts
+++ b/libs/feature/resource/server/src/lib/events/event.controller.spec.ts
@@ -1,0 +1,30 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { ResourceEventController } from './event.controller'
+import { ResourceEventEntity } from './event.entity'
+import { ResourceEventService } from './event.service'
+
+describe('ResourceEventController', () => {
+  let controller: ResourceEventController
+  let service: jest.Mocked<ResourceEventService>
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ResourceEventController],
+      providers: [{ provide: ResourceEventService, useValue: { search: jest.fn() } }],
+    }).compile()
+
+    controller = module.get(ResourceEventController)
+    service = module.get(ResourceEventService)
+  })
+
+  describe('search', () => {
+    it('devrait déléguer au service et retourner les événements mappés avec le total', async () => {
+      service.search.mockResolvedValue([[{ id: 'event-1' } as ResourceEventEntity], 1])
+
+      const result = await controller.search('resource-1', {})
+
+      expect(service.search).toHaveBeenCalledWith('resource-1', {})
+      expect(result.total).toBe(1)
+    })
+  })
+})

--- a/libs/feature/resource/server/src/lib/events/event.service.spec.ts
+++ b/libs/feature/resource/server/src/lib/events/event.service.spec.ts
@@ -1,0 +1,55 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { getRepositoryToken } from '@nestjs/typeorm'
+import { MockRepository, mockRepository, mockSelectQueryBuilder } from '@platon/core/testing/server'
+import { ResourceEventEntity } from './event.entity'
+import { ResourceEventService } from './event.service'
+
+describe('ResourceEventService', () => {
+  let service: ResourceEventService
+  let repository: MockRepository<ResourceEventEntity>
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ResourceEventService,
+        { provide: getRepositoryToken(ResourceEventEntity), useValue: mockRepository<ResourceEventEntity>() },
+      ],
+    }).compile()
+
+    service = module.get(ResourceEventService)
+    repository = module.get(getRepositoryToken(ResourceEventEntity))
+  })
+
+  describe('search', () => {
+    it('devrait filtrer par ressource et trier par date décroissante', async () => {
+      const qb = mockSelectQueryBuilder<ResourceEventEntity>()
+      repository.createQueryBuilder.mockReturnValue(qb)
+
+      await service.search('resource-1')
+
+      expect(qb.where).toHaveBeenCalledWith('resource_id = :resourceId', { resourceId: 'resource-1' })
+      expect(qb.orderBy).toHaveBeenCalledWith('created_at', 'DESC')
+    })
+
+    it('devrait appliquer offset et limit', async () => {
+      const qb = mockSelectQueryBuilder<ResourceEventEntity>()
+      repository.createQueryBuilder.mockReturnValue(qb)
+
+      await service.search('resource-1', { offset: 2, limit: 8 })
+
+      expect(qb.offset).toHaveBeenCalledWith(2)
+      expect(qb.limit).toHaveBeenCalledWith(8)
+    })
+
+    it('devrait retourner le résultat de getManyAndCount', async () => {
+      const qb = mockSelectQueryBuilder<ResourceEventEntity>()
+      const events = [{ id: 'event-1' } as ResourceEventEntity]
+      qb.getManyAndCount.mockResolvedValue([events, 1])
+      repository.createQueryBuilder.mockReturnValue(qb)
+
+      const result = await service.search('resource-1')
+
+      expect(result).toEqual([events, 1])
+    })
+  })
+})

--- a/libs/feature/resource/server/src/lib/events/event.subscriber.spec.ts
+++ b/libs/feature/resource/server/src/lib/events/event.subscriber.spec.ts
@@ -1,0 +1,135 @@
+import { UserService } from '@platon/core/server'
+import { NotificationService } from '@platon/feature/notification/server'
+import { ResourceEventTypes } from '@platon/feature/resource/common'
+import { DataSource } from 'typeorm'
+import { ResourceService } from '../resource.service'
+import { ResourceEventSubscriber } from './event.subscriber'
+
+describe('ResourceEventSubscriber', () => {
+  let subscriber: ResourceEventSubscriber
+  let dataSource: { subscribers: unknown[] }
+  let userService: jest.Mocked<UserService>
+  let resourceService: jest.Mocked<ResourceService>
+  let notificationService: jest.Mocked<NotificationService>
+
+  beforeEach(() => {
+    dataSource = { subscribers: [] }
+    userService = { search: jest.fn() } as unknown as jest.Mocked<UserService>
+    resourceService = {
+      notificationWatchers: jest.fn().mockResolvedValue([]),
+    } as unknown as jest.Mocked<ResourceService>
+    notificationService = {
+      sendToAllUsers: jest.fn().mockResolvedValue(undefined),
+    } as unknown as jest.Mocked<NotificationService>
+    subscriber = new ResourceEventSubscriber(
+      dataSource as unknown as DataSource,
+      userService,
+      resourceService,
+      notificationService
+    )
+  })
+
+  it("devrait s'enregistrer auprès du DataSource", () => {
+    expect(dataSource.subscribers).toContain(subscriber)
+  })
+
+  const buildEvent = (entity: Record<string, unknown> | undefined, manager: Record<string, unknown> = {}) => ({
+    entity,
+    manager,
+  })
+
+  it("ne devrait rien faire si l'entité est absente", async () => {
+    await subscriber.afterInsert(buildEvent(undefined) as never)
+
+    expect(notificationService.sendToAllUsers).not.toHaveBeenCalled()
+  })
+
+  it('ne devrait pas notifier un changement de statut envoyé sur le parent (pas la ressource cible)', async () => {
+    const event = buildEvent({
+      id: 'evt-1',
+      type: ResourceEventTypes.RESOURCE_STATUS_CHANGE,
+      resourceId: 'parent-1',
+      data: { resourceId: 'target-1' },
+    })
+
+    await subscriber.afterInsert(event as never)
+
+    expect(notificationService.sendToAllUsers).not.toHaveBeenCalled()
+  })
+
+  it('devrait notifier les observateurs pour un changement de statut de la ressource cible', async () => {
+    resourceService.notificationWatchers.mockResolvedValue(['user-1', 'actor-1'])
+    const event = buildEvent({
+      id: 'evt-1',
+      type: ResourceEventTypes.RESOURCE_STATUS_CHANGE,
+      resourceId: 'target-1',
+      actorId: 'actor-1',
+      data: { resourceId: 'target-1' },
+    })
+
+    await subscriber.afterInsert(event as never)
+
+    expect(notificationService.sendToAllUsers).toHaveBeenCalledWith(
+      ['user-1'],
+      expect.objectContaining({ type: 'RESOURCE-EVENT' })
+    )
+  })
+
+  it("devrait notifier tous les admins pour une demande d'adhésion (auto-jointure)", async () => {
+    userService.search.mockResolvedValue([[{ id: 'admin-1' }, { id: 'admin-2' }] as never, 2])
+    const event = buildEvent({
+      id: 'evt-1',
+      type: ResourceEventTypes.MEMBER_CREATE,
+      resourceId: 'r1',
+      actorId: 'user-1',
+      data: { userId: 'user-1' },
+    })
+
+    await subscriber.afterInsert(event as never)
+
+    expect(userService.search).toHaveBeenCalledWith({ roles: ['admin'] })
+    expect(notificationService.sendToAllUsers).toHaveBeenCalledWith(['admin-1', 'admin-2'], expect.anything())
+  })
+
+  it("devrait notifier les observateurs (hors acteur) pour une adhésion ajoutée par quelqu'un d'autre", async () => {
+    resourceService.notificationWatchers.mockResolvedValue(['user-1', 'admin-1'])
+    const event = buildEvent({
+      id: 'evt-1',
+      type: ResourceEventTypes.MEMBER_CREATE,
+      resourceId: 'r1',
+      actorId: 'admin-1',
+      data: { userId: 'user-1' },
+    })
+
+    await subscriber.afterInsert(event as never)
+
+    expect(notificationService.sendToAllUsers).toHaveBeenCalledWith(['user-1'], expect.anything())
+  })
+
+  it("devrait notifier uniquement l'acteur pour un retrait de membre", async () => {
+    const event = buildEvent({
+      id: 'evt-1',
+      type: ResourceEventTypes.MEMBER_REMOVE,
+      resourceId: 'r1',
+      actorId: 'actor-1',
+      data: {},
+    })
+
+    await subscriber.afterInsert(event as never)
+
+    expect(notificationService.sendToAllUsers).toHaveBeenCalledWith(['actor-1'], expect.anything())
+  })
+
+  it("ne devrait pas laisser fuiter une erreur d'envoi de notification", async () => {
+    notificationService.sendToAllUsers.mockRejectedValue(new Error('notif failed'))
+    const event = buildEvent({
+      id: 'evt-1',
+      type: ResourceEventTypes.MEMBER_REMOVE,
+      resourceId: 'r1',
+      actorId: 'actor-1',
+      data: {},
+    })
+
+    await expect(subscriber.afterInsert(event as never)).resolves.toBeUndefined()
+  })
+})

--- a/libs/feature/resource/server/src/lib/files/file.controller.spec.ts
+++ b/libs/feature/resource/server/src/lib/files/file.controller.spec.ts
@@ -1,0 +1,432 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { ConfigService } from '@nestjs/config'
+import { BadRequestResponse, UnauthorizedResponse } from '@platon/core/common'
+import { EventService, IRequest } from '@platon/core/server'
+import { ResourceTypes } from '@platon/feature/resource/common'
+import { ResourceDependencyService } from '../dependency'
+import { ResourceEntity } from '../resource.entity'
+import { ResourceFileController } from './file.controller'
+import { ResourceFileService } from './file.service'
+
+describe('ResourceFileController', () => {
+  let controller: ResourceFileController
+  let fileService: jest.Mocked<ResourceFileService>
+  let eventService: jest.Mocked<EventService>
+  let dependencyService: jest.Mocked<ResourceDependencyService>
+
+  const buildResource = (overrides: Partial<ResourceEntity> = {}): ResourceEntity =>
+    ({ id: 'resource-1', name: 'Resource 1', type: ResourceTypes.EXERCISE, ...overrides } as ResourceEntity)
+
+  const buildRepo = (overrides: Record<string, unknown> = {}) => ({
+    log: jest.fn(),
+    release: jest.fn(),
+    versions: jest.fn(),
+    listZipFiles: jest.fn(),
+    describe: jest.fn(),
+    search: jest.fn(),
+    read: jest.fn(),
+    write: jest.fn(),
+    upload: jest.fn(),
+    withNoCommit: jest.fn((fn: () => Promise<void>) => fn()),
+    touch: jest.fn(),
+    mkdir: jest.fn(),
+    commit: jest.fn(),
+    unzip: jest.fn(),
+    unzipFile: jest.fn(),
+    rename: jest.fn(),
+    move: jest.fn(),
+    remove: jest.fn(),
+    ...overrides,
+  })
+
+  const buildReq = (params: Record<string, string> = {}, overrides: Record<string, unknown> = {}): IRequest =>
+    ({
+      params: { path: '', ...params },
+      user: { id: 'user-1', role: 'teacher', ...overrides },
+    } as unknown as IRequest)
+
+  const buildRes = () => ({ set: jest.fn() } as never)
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ResourceFileController],
+      providers: [
+        { provide: ResourceFileService, useValue: { repo: jest.fn(), compile: jest.fn() } },
+        { provide: EventService, useValue: { emit: jest.fn() } },
+        { provide: ConfigService, useValue: { get: jest.fn().mockReturnValue(3600) } },
+        {
+          provide: ResourceDependencyService,
+          useValue: { createDependencyForNewVersion: jest.fn() },
+        },
+      ],
+    }).compile()
+
+    controller = module.get(ResourceFileController)
+    fileService = module.get(ResourceFileService)
+    eventService = module.get(EventService)
+    dependencyService = module.get(ResourceDependencyService)
+  })
+
+  describe('log', () => {
+    it('devrait rejeter avec UnauthorizedResponse sans permission de lecture', async () => {
+      fileService.repo.mockResolvedValue({
+        repo: buildRepo(),
+        resource: buildResource(),
+        permissions: { read: false },
+      } as never)
+
+      await expect(controller.log(buildReq(), 'resource-1')).rejects.toBeInstanceOf(UnauthorizedResponse)
+    })
+
+    it('devrait retourner le log du dépôt', async () => {
+      const repo = buildRepo({ log: jest.fn().mockResolvedValue(['commit1']) })
+      fileService.repo.mockResolvedValue({ repo, resource: buildResource(), permissions: { read: true } } as never)
+
+      const result = await controller.log(buildReq(), 'resource-1')
+
+      expect(result).toEqual(['commit1'])
+    })
+  })
+
+  describe('release', () => {
+    it("devrait rejeter avec UnauthorizedResponse sans permission d'écriture", async () => {
+      fileService.repo.mockResolvedValue({
+        repo: buildRepo(),
+        resource: buildResource(),
+        permissions: { write: false },
+      } as never)
+
+      await expect(
+        controller.release(buildReq(), 'resource-1', { name: 'v2', message: 'release' })
+      ).rejects.toBeInstanceOf(UnauthorizedResponse)
+    })
+
+    it('devrait créer une nouvelle version, émettre un événement, et retourner les versions', async () => {
+      const repo = buildRepo({ versions: jest.fn().mockResolvedValue({ all: [{ tag: 'v2' }] }) })
+      const resource = buildResource({ template: undefined } as never)
+      fileService.repo.mockResolvedValue({ repo, resource, permissions: { write: true } } as never)
+
+      const result = await controller.release(buildReq(), 'resource-1', { name: 'v2', message: 'release' })
+
+      expect(repo.release).toHaveBeenCalledWith('v2', 'release')
+      expect(dependencyService.createDependencyForNewVersion).not.toHaveBeenCalled()
+      expect(eventService.emit).toHaveBeenCalledWith(expect.any(String), { repo, resource })
+      expect(result).toEqual({ all: [{ tag: 'v2' }] })
+    })
+
+    it("devrait créer une dépendance de version si la ressource hérite d'un template", async () => {
+      const repo = buildRepo()
+      const resource = buildResource({ template: {} } as never)
+      fileService.repo.mockResolvedValue({ repo, resource, permissions: { write: true } } as never)
+
+      await controller.release(buildReq(), 'resource-1', { name: 'v2', message: 'release' })
+
+      expect(dependencyService.createDependencyForNewVersion).toHaveBeenCalledWith('resource-1', 'v2')
+    })
+  })
+
+  describe('compileExercise', () => {
+    it('devrait retourner le résultat de la compilation', async () => {
+      fileService.compile.mockResolvedValue({ source: { errors: [] } } as never)
+
+      const result = await controller.compileExercise(buildReq(), 'resource-1')
+
+      expect(fileService.compile).toHaveBeenCalledWith(
+        expect.objectContaining({ resourceId: 'resource-1', withAst: true })
+      )
+      expect(result).toEqual({ errors: [] })
+    })
+  })
+
+  describe('transformExercise', () => {
+    it('devrait déléguer la transformation au compilateur', async () => {
+      const toExercise = jest.fn().mockReturnValue('output')
+      fileService.compile.mockResolvedValue({ compiler: { toExercise } } as never)
+
+      const result = await controller.transformExercise(buildReq(), 'resource-1', 'latest', {
+        changes: { a: 1 },
+        includes: ['x'],
+      } as never)
+
+      expect(toExercise).toHaveBeenCalledWith({ variableChanges: { a: 1 }, includeChanges: ['x'] })
+      expect(result).toBe('output')
+    })
+  })
+
+  describe('get', () => {
+    it('devrait retourner la liste des fichiers zip quand zipList est demandé', async () => {
+      const repo = buildRepo({ listZipFiles: jest.fn().mockResolvedValue(['a.txt']) })
+      fileService.repo.mockResolvedValue({ repo, resource: buildResource(), permissions: { write: true } } as never)
+
+      const result = await controller.get(buildReq({ path: 'archive.zip' }), buildRes(), 'resource-1', {
+        zipList: true,
+      } as never)
+
+      expect(result).toEqual(['a.txt'])
+    })
+
+    it('devrait retourner describe()', async () => {
+      const repo = buildRepo({ describe: jest.fn().mockResolvedValue({ ok: true }) })
+      fileService.repo.mockResolvedValue({ repo, resource: buildResource(), permissions: { write: true } } as never)
+
+      const result = await controller.get(buildReq(), buildRes(), 'resource-1', { describe: true } as never)
+
+      expect(result).toEqual({ ok: true })
+    })
+
+    it('devrait retourner versions()', async () => {
+      const repo = buildRepo({ versions: jest.fn().mockResolvedValue({ all: [] }) })
+      fileService.repo.mockResolvedValue({ repo, resource: buildResource(), permissions: { write: true } } as never)
+
+      const result = await controller.get(buildReq(), buildRes(), 'resource-1', { versions: true } as never)
+
+      expect(result).toEqual({ all: [] })
+    })
+
+    it('devrait déléguer la recherche au dépôt', async () => {
+      const repo = buildRepo({ search: jest.fn().mockResolvedValue([]) })
+      fileService.repo.mockResolvedValue({ repo, resource: buildResource(), permissions: { write: true } } as never)
+
+      await controller.get(buildReq(), buildRes(), 'resource-1', {
+        search: 'foo',
+        match_case: true,
+        match_word: false,
+        use_regex: true,
+      } as never)
+
+      expect(repo.search).toHaveBeenCalledWith({ query: 'foo', matchCase: true, matchWord: false, useRegex: true })
+    })
+
+    it("devrait rejeter l'arbre d'exercices pour un type de ressource non-activité", async () => {
+      const repo = buildRepo()
+      fileService.repo.mockResolvedValue({
+        repo,
+        resource: buildResource({ type: ResourceTypes.EXERCISE }),
+        permissions: { write: true },
+      } as never)
+
+      await expect(
+        controller.get(buildReq(), buildRes(), 'resource-1', { exerciseTree: true } as never)
+      ).rejects.toBeInstanceOf(BadRequestResponse)
+    })
+
+    it("devrait retourner l'arbre d'exercices pour une activité", async () => {
+      const main = JSON.stringify({
+        exerciseGroups: { group1: { name: 'Group 1', exercises: [{ id: 'e1', version: 'v1', resource: 'r1' }] } },
+      })
+      const repo = buildRepo({
+        read: jest.fn().mockResolvedValue([{}, Promise.resolve(new TextEncoder().encode(main))]),
+      })
+      fileService.repo.mockResolvedValue({
+        repo,
+        resource: buildResource({ type: ResourceTypes.ACTIVITY }),
+        permissions: { write: true },
+      } as never)
+
+      const result = await controller.get(buildReq(), buildRes(), 'resource-1', { exerciseTree: true } as never)
+
+      expect(result).toEqual([
+        { id: 'group1', name: 'Group 1', exercises: [{ id: 'e1', version: 'v1', resource: 'r1' }] },
+      ])
+    })
+
+    it('devrait retourner le contenu texte du fichier lu par défaut', async () => {
+      const node = { type: 'file', path: 'main.ple', version: 'latest' }
+      const repo = buildRepo({
+        read: jest.fn().mockResolvedValue([node, Promise.resolve(new TextEncoder().encode('content'))]),
+      })
+      fileService.repo.mockResolvedValue({ repo, resource: buildResource(), permissions: { write: true } } as never)
+
+      const result = await controller.get(buildReq(), buildRes(), 'resource-1', {} as never)
+
+      expect(result).toBe('content')
+    })
+
+    it('devrait injecter le code de ressource et readOnly sur un noeud dossier', async () => {
+      const node = {
+        type: 'folder',
+        path: 'src',
+        version: 'latest',
+        children: [{ type: 'file', path: 'src/a.ple', version: 'latest' }],
+      }
+      const repo = buildRepo({ read: jest.fn().mockResolvedValue([node, undefined]) })
+      fileService.repo.mockResolvedValue({
+        repo,
+        resource: buildResource({ code: 'my-code' } as never),
+        permissions: { write: false },
+      } as never)
+
+      const result = await controller.get(buildReq(), buildRes(), 'resource-1', {} as never)
+
+      expect((result as never as { resourceCode: string }).resourceCode).toBe('my-code')
+      expect((result as never as { readOnly: boolean }).readOnly).toBe(true)
+      expect((result as never as { children: { readOnly: boolean }[] }).children[0].readOnly).toBe(true)
+    })
+  })
+
+  describe('put', () => {
+    it("devrait rejeter avec UnauthorizedResponse sans permission d'écriture", async () => {
+      fileService.repo.mockResolvedValue({
+        repo: buildRepo(),
+        resource: buildResource(),
+        permissions: { write: false },
+      } as never)
+
+      await expect(
+        controller.put(buildReq(), 'resource-1', { content: 'x' }, undefined as never)
+      ).rejects.toBeInstanceOf(UnauthorizedResponse)
+    })
+
+    it('devrait rejeter si le contenu est manquant et aucun bundle fourni', async () => {
+      fileService.repo.mockResolvedValue({
+        repo: buildRepo(),
+        resource: buildResource(),
+        permissions: { write: true },
+      } as never)
+
+      await expect(controller.put(buildReq(), 'resource-1', {}, undefined as never)).rejects.toBeInstanceOf(
+        BadRequestResponse
+      )
+    })
+
+    it('devrait écrire le contenu et émettre un événement de modification', async () => {
+      const repo = buildRepo({
+        read: jest.fn().mockResolvedValue([{}, Promise.resolve(new TextEncoder().encode('old'))]),
+      })
+      fileService.repo.mockResolvedValue({ repo, resource: buildResource(), permissions: { write: true } } as never)
+
+      await controller.put(buildReq(), 'resource-1', { content: 'new' }, undefined as never)
+
+      expect(repo.write).toHaveBeenCalledWith('', 'new')
+      expect(eventService.emit).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ operation: 'update', newContent: 'new' })
+      )
+    })
+  })
+
+  describe('post', () => {
+    it("devrait rejeter avec UnauthorizedResponse sans permission d'écriture", async () => {
+      fileService.repo.mockResolvedValue({
+        repo: buildRepo(),
+        resource: buildResource(),
+        permissions: { write: false },
+      } as never)
+
+      await expect(controller.post(buildReq(), 'resource-1', [], undefined as never)).rejects.toBeInstanceOf(
+        UnauthorizedResponse
+      )
+    })
+
+    it('devrait uploader un fichier binaire et émettre un événement de création', async () => {
+      const repo = buildRepo({ upload: jest.fn().mockResolvedValue('uploaded-name') })
+      fileService.repo.mockResolvedValue({ repo, resource: buildResource(), permissions: { write: true } } as never)
+      const file = { path: '/tmp/upload', originalname: 'photo.png' } as Express.Multer.File
+
+      const result = await controller.post(buildReq(), 'resource-1', [], file)
+
+      expect(repo.upload).toHaveBeenCalled()
+      expect((result as { resource: string }).resource).toBe('uploaded-name')
+    })
+
+    it('devrait créer les fichiers/dossiers demandés dans une seule transaction', async () => {
+      const repo = buildRepo()
+      fileService.repo.mockResolvedValue({ repo, resource: buildResource(), permissions: { write: true } } as never)
+
+      await controller.post(
+        buildReq(),
+        'resource-1',
+        [{ path: 'a.txt', content: 'hello' }, { path: 'folder' }],
+        undefined as never
+      )
+
+      expect(repo.touch).toHaveBeenCalledWith('a.txt', 'hello')
+      expect(repo.mkdir).toHaveBeenCalledWith('folder')
+      expect(repo.commit).toHaveBeenCalled()
+    })
+  })
+
+  describe('patch', () => {
+    it("devrait rejeter avec UnauthorizedResponse sans permission d'écriture", async () => {
+      fileService.repo.mockResolvedValue({
+        repo: buildRepo(),
+        resource: buildResource(),
+        permissions: { write: false },
+      } as never)
+
+      await expect(controller.patch(buildReq(), 'resource-1', {})).rejects.toBeInstanceOf(UnauthorizedResponse)
+    })
+
+    it('devrait dézipper avec un fichier spécifique', async () => {
+      const repo = buildRepo()
+      fileService.repo.mockResolvedValue({ repo, resource: buildResource(), permissions: { write: true } } as never)
+
+      await controller.patch(buildReq(), 'resource-1', { unzip: true, unzipFile: 'a.txt' } as never)
+
+      expect(repo.unzipFile).toHaveBeenCalledWith('', 'a.txt')
+      expect(repo.unzip).not.toHaveBeenCalled()
+    })
+
+    it("devrait rejeter si aucune destination n'est fournie hors dézippage", async () => {
+      const repo = buildRepo()
+      fileService.repo.mockResolvedValue({ repo, resource: buildResource(), permissions: { write: true } } as never)
+
+      await expect(controller.patch(buildReq(), 'resource-1', {} as never)).rejects.toBeInstanceOf(BadRequestResponse)
+    })
+
+    it('devrait renommer et émettre deux événements (delete puis create)', async () => {
+      const repo = buildRepo()
+      fileService.repo.mockResolvedValue({ repo, resource: buildResource(), permissions: { write: true } } as never)
+
+      await controller.patch(buildReq(), 'resource-1', { rename: true, destination: 'new-name' } as never)
+
+      expect(repo.rename).toHaveBeenCalledWith('', 'new-name')
+      expect(repo.move).not.toHaveBeenCalled()
+      expect(eventService.emit).toHaveBeenCalledTimes(2)
+    })
+
+    it('devrait déplacer et émettre un seul événement de création', async () => {
+      const repo = buildRepo()
+      fileService.repo.mockResolvedValue({ repo, resource: buildResource(), permissions: { write: true } } as never)
+
+      await controller.patch(buildReq(), 'resource-1', { destination: 'new-folder', copy: true } as never)
+
+      expect(repo.move).toHaveBeenCalledWith('', 'new-folder', true)
+      expect(eventService.emit).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('delete', () => {
+    it("devrait rejeter avec UnauthorizedResponse sans permission d'écriture", async () => {
+      fileService.repo.mockResolvedValue({
+        repo: buildRepo(),
+        resource: buildResource(),
+        permissions: { write: false },
+      } as never)
+
+      await expect(controller.delete(buildReq(), 'resource-1')).rejects.toBeInstanceOf(UnauthorizedResponse)
+    })
+
+    it("devrait rejeter la suppression d'un cercle non personnel par un non-admin", async () => {
+      const resource = buildResource({ type: ResourceTypes.CIRCLE, personal: false })
+      fileService.repo.mockResolvedValue({ repo: buildRepo(), resource, permissions: { write: true } } as never)
+
+      await expect(controller.delete(buildReq({}, { role: 'teacher' }), 'resource-1')).rejects.toBeInstanceOf(
+        UnauthorizedResponse
+      )
+    })
+
+    it('devrait supprimer le fichier et émettre un événement', async () => {
+      const repo = buildRepo()
+      fileService.repo.mockResolvedValue({ repo, resource: buildResource(), permissions: { write: true } } as never)
+
+      await controller.delete(buildReq({ path: 'to-delete.txt' }), 'resource-1')
+
+      expect(repo.remove).toHaveBeenCalledWith('to-delete.txt')
+      expect(eventService.emit).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ operation: 'delete' })
+      )
+    })
+  })
+})

--- a/libs/feature/resource/server/src/lib/files/file.service.spec.ts
+++ b/libs/feature/resource/server/src/lib/files/file.service.spec.ts
@@ -1,0 +1,176 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { NotFoundResponse } from '@platon/core/common'
+import { IRequest } from '@platon/core/server'
+import { createUserEntity } from '@platon/core/testing/server'
+import { ResourceTypes } from '@platon/feature/resource/common'
+import { Optional } from 'typescript-optional'
+import { ResourceDependencyService } from '../dependency'
+import { ResourcePermissionService } from '../permissions/permissions.service'
+import { ResourceEntity } from '../resource.entity'
+import { ResourceService } from '../resource.service'
+import { ResourceFileService } from './file.service'
+import { Repo } from './repo'
+
+jest.mock('./repo')
+
+describe('ResourceFileService', () => {
+  let service: ResourceFileService
+  let resourceService: jest.Mocked<ResourceService>
+  let permissionService: jest.Mocked<ResourcePermissionService>
+
+  const fakeRepo = { copy: jest.fn(), read: jest.fn() }
+
+  const buildResource = (overrides: Partial<ResourceEntity> = {}): ResourceEntity =>
+    ({ id: 'resource-1', type: ResourceTypes.EXERCISE, ...overrides } as ResourceEntity)
+
+  beforeEach(async () => {
+    jest.clearAllMocks()
+    ;(Repo.get as jest.Mock).mockResolvedValue(fakeRepo)
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ResourceFileService,
+        {
+          provide: ResourceService,
+          useValue: { findByIdOrCode: jest.fn(), getPersonal: jest.fn() },
+        },
+        { provide: ResourcePermissionService, useValue: { userPermissionsOnResource: jest.fn() } },
+        { provide: ResourceDependencyService, useValue: { getTemplateDependency: jest.fn() } },
+      ],
+    }).compile()
+
+    service = module.get(ResourceFileService)
+    resourceService = module.get(ResourceService)
+    permissionService = module.get(ResourcePermissionService)
+    permissionService.userPermissionsOnResource.mockResolvedValue({ read: true, write: true } as never)
+  })
+
+  describe('repo', () => {
+    it('devrait résoudre la ressource par id/code quand un identifiant string est fourni', async () => {
+      const resource = buildResource()
+      resourceService.findByIdOrCode.mockResolvedValue(Optional.of(resource))
+
+      const result = await service.repo('resource-1')
+
+      expect(resourceService.findByIdOrCode).toHaveBeenCalledWith('resource-1')
+      expect(result.resource).toBe(resource)
+    })
+
+    it("devrait rejeter avec NotFoundResponse si l'identifiant string ne correspond à aucune ressource", async () => {
+      resourceService.findByIdOrCode.mockResolvedValue(Optional.empty())
+
+      await expect(service.repo('unknown')).rejects.toBeInstanceOf(NotFoundResponse)
+    })
+
+    it("devrait utiliser directement l'entité fournie sans requête supplémentaire", async () => {
+      const resource = buildResource()
+
+      await service.repo(resource)
+
+      expect(resourceService.findByIdOrCode).not.toHaveBeenCalled()
+    })
+
+    it('devrait résoudre le cercle personnel comme userCircle quand la requête a un utilisateur', async () => {
+      const resource = buildResource()
+      const user = createUserEntity({ id: 'user-1' })
+      resourceService.getPersonal.mockResolvedValue(buildResource({ id: 'personal-circle' }))
+      const req = { user } as unknown as IRequest
+
+      await service.repo(resource, req)
+
+      expect(resourceService.getPersonal).toHaveBeenCalledWith(user)
+      expect(Repo.get).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ userCircle: 'personal-circle' })
+      )
+    })
+
+    it('ne devrait pas résoudre de userCircle sans requête', async () => {
+      const resource = buildResource()
+
+      await service.repo(resource)
+
+      expect(resourceService.getPersonal).not.toHaveBeenCalled()
+      expect(Repo.get).toHaveBeenCalledWith(expect.any(String), expect.objectContaining({ userCircle: undefined }))
+    })
+
+    it('devrait générer les fichiers par défaut du template quand templateId est défini et defaultFiles non fourni', async () => {
+      const resource = buildResource({ templateId: 'template-1', templateVersion: 'v2' } as never)
+
+      await service.repo(resource)
+
+      const options = (Repo.get as jest.Mock).mock.calls[0][1]
+      expect(Object.keys(options.defaultFiles)).toEqual(expect.arrayContaining(['main.ple', 'main.plo', 'readme.md']))
+    })
+
+    it('devrait utiliser les defaultFiles fournis en priorité même si templateId est défini', async () => {
+      const resource = buildResource({ templateId: 'template-1' } as never)
+
+      await service.repo(resource, undefined, { 'custom.txt': 'content' })
+
+      const options = (Repo.get as jest.Mock).mock.calls[0][1]
+      expect(options.defaultFiles).toEqual({ 'custom.txt': 'content' })
+    })
+
+    it('devrait mapper le type de ressource vers le bon répertoire', async () => {
+      await service.repo(buildResource({ type: ResourceTypes.CIRCLE }))
+      expect((Repo.get as jest.Mock).mock.calls[0][0]).toContain('circles')
+
+      await service.repo(buildResource({ type: ResourceTypes.ACTIVITY }))
+      expect((Repo.get as jest.Mock).mock.calls[1][0]).toContain('activites')
+    })
+  })
+
+  describe('copy', () => {
+    it('devrait copier le dépôt source vers le dépôt destination', async () => {
+      const srcRepo = { copy: jest.fn() }
+      const dstRepo = {}
+      ;(Repo.get as jest.Mock).mockResolvedValueOnce(srcRepo).mockResolvedValueOnce(dstRepo)
+      resourceService.findByIdOrCode.mockImplementation((id) => Promise.resolve(Optional.of(buildResource({ id }))))
+
+      await service.copy('src-1', 'dst-1')
+
+      expect(srcRepo.copy).toHaveBeenCalledWith(dstRepo)
+    })
+  })
+
+  describe('getFileContent', () => {
+    it('devrait lire le fichier à la version demandée et retourner son contenu', async () => {
+      const content = new Uint8Array([1, 2, 3])
+      fakeRepo.read.mockResolvedValue([{}, content])
+      resourceService.findByIdOrCode.mockResolvedValue(Optional.of(buildResource()))
+
+      const result = await service.getFileContent('resource-1', 'main.ple', 'v2')
+
+      expect(fakeRepo.read).toHaveBeenCalledWith('main.ple', 'v2')
+      expect(result).toBe(content)
+    })
+
+    it("devrait utiliser LATEST par défaut si aucune version n'est fournie", async () => {
+      fakeRepo.read.mockResolvedValue([{}, new Uint8Array()])
+      resourceService.findByIdOrCode.mockResolvedValue(Optional.of(buildResource()))
+
+      await service.getFileContent('resource-1', 'main.ple')
+
+      expect(fakeRepo.read).toHaveBeenCalledWith('main.ple', 'latest')
+    })
+  })
+
+  describe('getTitle', () => {
+    it('devrait retourner le nom de la ressource si trouvée', async () => {
+      resourceService.findByIdOrCode.mockResolvedValue(Optional.of(buildResource({ name: 'My Resource' } as never)))
+
+      const result = await service.getTitle('resource-1')
+
+      expect(result).toBe('My Resource')
+    })
+
+    it('devrait retourner une valeur par défaut si la ressource est introuvable', async () => {
+      resourceService.findByIdOrCode.mockResolvedValue(Optional.empty())
+
+      const result = await service.getTitle('unknown')
+
+      expect(result).toBe('À faire')
+    })
+  })
+})

--- a/libs/feature/resource/server/src/lib/invitations/invitation.controller.spec.ts
+++ b/libs/feature/resource/server/src/lib/invitations/invitation.controller.spec.ts
@@ -1,0 +1,96 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { NotFoundResponse } from '@platon/core/common'
+import { IRequest } from '@platon/core/server'
+import { Optional } from 'typescript-optional'
+import { ResourceInvitationController } from './invitation.controller'
+import { ResourceInvitationEntity } from './invitation.entity'
+import { ResourceInvitationService } from './invitation.service'
+
+describe('ResourceInvitationController', () => {
+  let controller: ResourceInvitationController
+  let service: jest.Mocked<ResourceInvitationService>
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ResourceInvitationController],
+      providers: [
+        {
+          provide: ResourceInvitationService,
+          useValue: {
+            findAll: jest.fn(),
+            findLastOfInviteeInResource: jest.fn(),
+            create: jest.fn(),
+            accept: jest.fn(),
+            delete: jest.fn(),
+          },
+        },
+      ],
+    }).compile()
+
+    controller = module.get(ResourceInvitationController)
+    service = module.get(ResourceInvitationService)
+  })
+
+  describe('list', () => {
+    it('devrait retourner les invitations mappées avec le total', async () => {
+      service.findAll.mockResolvedValue([[{ resourceId: 'r1' } as ResourceInvitationEntity], 1])
+
+      const result = await controller.list('r1')
+
+      expect(service.findAll).toHaveBeenCalledWith('r1')
+      expect(result.total).toBe(1)
+    })
+  })
+
+  describe('find', () => {
+    it("devrait rejeter avec NotFoundResponse si l'invitation est introuvable", async () => {
+      service.findLastOfInviteeInResource.mockResolvedValue(Optional.empty())
+
+      await expect(controller.find('u1', 'r1')).rejects.toBeInstanceOf(NotFoundResponse)
+    })
+
+    it("devrait retourner l'invitation mappée", async () => {
+      service.findLastOfInviteeInResource.mockResolvedValue(
+        Optional.of({ resourceId: 'r1', inviteeId: 'u1' } as ResourceInvitationEntity)
+      )
+
+      const result = await controller.find('u1', 'r1')
+
+      expect(result.resource).toBeDefined()
+    })
+  })
+
+  describe('invite', () => {
+    it("devrait créer l'invitation avec l'utilisateur courant comme invitant", async () => {
+      const req = { user: { id: 'admin-1' } } as unknown as IRequest
+      service.create.mockResolvedValue({ resourceId: 'r1' } as ResourceInvitationEntity)
+
+      await controller.invite(req, 'r1', { inviteeId: 'u1' } as never)
+
+      expect(service.create).toHaveBeenCalledWith(
+        expect.objectContaining({ resourceId: 'r1', inviterId: 'admin-1', inviteeId: 'u1' })
+      )
+    })
+  })
+
+  describe('accept', () => {
+    it('devrait déléguer au service et retourner le membre créé', async () => {
+      service.accept.mockResolvedValue({ resourceId: 'r1', userId: 'u1' } as never)
+
+      const result = await controller.accept('u1', 'r1')
+
+      expect(service.accept).toHaveBeenCalledWith('r1', 'u1')
+      expect(result.resource).toBeDefined()
+    })
+  })
+
+  describe('decline', () => {
+    it('devrait déléguer la suppression au service', async () => {
+      const req = { user: { id: 'admin-1' } } as unknown as IRequest
+
+      await controller.decline(req, 'u1', 'r1')
+
+      expect(service.delete).toHaveBeenCalledWith('r1', 'u1')
+    })
+  })
+})

--- a/libs/feature/resource/server/src/lib/invitations/invitation.service.spec.ts
+++ b/libs/feature/resource/server/src/lib/invitations/invitation.service.spec.ts
@@ -1,0 +1,151 @@
+import { BadRequestException } from '@nestjs/common'
+import { Test, TestingModule } from '@nestjs/testing'
+import { getRepositoryToken } from '@nestjs/typeorm'
+import { ForbiddenResponse, NotFoundResponse } from '@platon/core/common'
+import { MockRepository, mockRepository } from '@platon/core/testing/server'
+import { Optional } from 'typescript-optional'
+import { DataSource, EntityManager } from 'typeorm'
+import { ResourceMemberService } from '../members/member.service'
+import { ResourceInvitationEntity } from './invitation.entity'
+import { ResourceInvitationService } from './invitation.service'
+
+describe('ResourceInvitationService', () => {
+  let service: ResourceInvitationService
+  let repository: MockRepository<ResourceInvitationEntity>
+  let memberService: jest.Mocked<ResourceMemberService>
+  let dataSource: { transaction: jest.Mock }
+
+  beforeEach(async () => {
+    dataSource = { transaction: jest.fn() }
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ResourceInvitationService,
+        { provide: DataSource, useValue: dataSource },
+        {
+          provide: getRepositoryToken(ResourceInvitationEntity),
+          useValue: mockRepository<ResourceInvitationEntity>(),
+        },
+        { provide: ResourceMemberService, useValue: { findByUserId: jest.fn(), create: jest.fn() } },
+      ],
+    }).compile()
+
+    service = module.get(ResourceInvitationService)
+    repository = module.get(getRepositoryToken(ResourceInvitationEntity))
+    memberService = module.get(ResourceMemberService)
+  })
+
+  describe('findLastOfInviteeInResource', () => {
+    it('devrait retourner la dernière invitation triée par date de création', async () => {
+      const invitation = { resourceId: 'r1', inviteeId: 'u1' } as ResourceInvitationEntity
+      repository.findOne.mockResolvedValue(invitation)
+
+      const result = await service.findLastOfInviteeInResource('r1', 'u1')
+
+      expect(repository.findOne).toHaveBeenCalledWith({
+        where: { resourceId: 'r1', inviteeId: 'u1' },
+        order: { createdAt: 'DESC' },
+      })
+      expect(result.get()).toBe(invitation)
+    })
+  })
+
+  describe('findAll / findAllByInviteeId', () => {
+    it('devrait lister les invitations par ressource', async () => {
+      repository.findAndCount.mockResolvedValue([[], 0])
+
+      await service.findAll('r1')
+
+      expect(repository.findAndCount).toHaveBeenCalledWith({ where: { resourceId: 'r1' } })
+    })
+
+    it('devrait lister les invitations par invité', async () => {
+      repository.findAndCount.mockResolvedValue([[], 0])
+
+      await service.findAllByInviteeId('u1')
+
+      expect(repository.findAndCount).toHaveBeenCalledWith({ where: { inviteeId: 'u1' } })
+    })
+  })
+
+  describe('create', () => {
+    it("devrait rejeter si l'invité est déjà membre de la ressource", async () => {
+      memberService.findByUserId.mockResolvedValue(Optional.of({ resourceId: 'r1', userId: 'u1' } as never))
+
+      await expect(service.create({ resourceId: 'r1', inviteeId: 'u1' })).rejects.toBeInstanceOf(BadRequestException)
+    })
+
+    it("devrait créer l'invitation si l'invité n'est pas déjà membre", async () => {
+      memberService.findByUserId.mockResolvedValue(Optional.empty())
+      const created = { resourceId: 'r1', inviteeId: 'u1' } as ResourceInvitationEntity
+      repository.save.mockResolvedValue(created)
+
+      const result = await service.create({ resourceId: 'r1', inviteeId: 'u1' })
+
+      expect(result).toBe(created)
+    })
+  })
+
+  describe('accept', () => {
+    const runTransaction = (manager: Partial<EntityManager>) =>
+      dataSource.transaction.mockImplementation((fn) => fn(manager))
+
+    it("devrait rejeter avec NotFoundResponse si l'invitation n'existe pas", async () => {
+      runTransaction({ findOne: jest.fn().mockResolvedValue(null) })
+
+      await expect(service.accept('r1', 'u1')).rejects.toBeInstanceOf(NotFoundResponse)
+    })
+
+    it("devrait rejeter avec ForbiddenResponse si l'invitation ne correspond pas à l'invité", async () => {
+      runTransaction({
+        findOne: jest.fn().mockResolvedValue({ resourceId: 'r1', inviteeId: 'someone-else' }),
+      })
+
+      await expect(service.accept('r1', 'u1')).rejects.toBeInstanceOf(ForbiddenResponse)
+    })
+
+    it("devrait supprimer la demande et créer une adhésion à partir des infos de l'invitation", async () => {
+      const invitation = {
+        resourceId: 'r1',
+        inviteeId: 'u1',
+        inviterId: 'admin-1',
+        permissions: { read: true, write: false },
+      }
+      const manager = { findOne: jest.fn().mockResolvedValue(invitation), remove: jest.fn() }
+      runTransaction(manager)
+      const createdMember = { resourceId: 'r1', userId: 'u1' } as never
+      memberService.create.mockResolvedValue(createdMember)
+
+      const result = await service.accept('r1', 'u1')
+
+      expect(manager.remove).toHaveBeenCalledWith(invitation)
+      expect(memberService.create).toHaveBeenCalledWith(
+        {
+          resourceId: 'r1',
+          userId: 'u1',
+          inviterId: 'admin-1',
+          permissions: { read: true, write: false },
+        },
+        manager
+      )
+      expect(result).toBe(createdMember)
+    })
+  })
+
+  describe('delete', () => {
+    it("devrait rejeter avec NotFoundResponse si l'invitation n'existe pas", async () => {
+      repository.findOne.mockResolvedValue(null)
+
+      await expect(service.delete('r1', 'u1')).rejects.toBeInstanceOf(NotFoundResponse)
+    })
+
+    it('devrait supprimer la dernière invitation trouvée', async () => {
+      const invitation = { resourceId: 'r1', inviteeId: 'u1' } as ResourceInvitationEntity
+      repository.findOne.mockResolvedValue(invitation)
+
+      await service.delete('r1', 'u1')
+
+      expect(repository.remove).toHaveBeenCalledWith(invitation)
+    })
+  })
+})

--- a/libs/feature/resource/server/src/lib/invitations/invitation.subscriber.spec.ts
+++ b/libs/feature/resource/server/src/lib/invitations/invitation.subscriber.spec.ts
@@ -1,0 +1,99 @@
+import { NotificationService } from '@platon/feature/notification/server'
+import { DataSource } from 'typeorm'
+import { ResourceInvitationSubscriber } from './invitation.subscriber'
+
+describe('ResourceInvitationSubscriber', () => {
+  let subscriber: ResourceInvitationSubscriber
+  let dataSource: { subscribers: unknown[] }
+  let notificationService: jest.Mocked<NotificationService>
+
+  beforeEach(() => {
+    dataSource = { subscribers: [] }
+    notificationService = {
+      sendToUser: jest.fn().mockResolvedValue(undefined),
+      deleteWhere: jest.fn().mockResolvedValue(0),
+    } as unknown as jest.Mocked<NotificationService>
+    subscriber = new ResourceInvitationSubscriber(dataSource as unknown as DataSource, notificationService)
+  })
+
+  it("devrait s'enregistrer auprès du DataSource", () => {
+    expect(dataSource.subscribers).toContain(subscriber)
+  })
+
+  describe('afterInsert', () => {
+    const buildManager = (overrides: Record<string, unknown> = {}) => ({
+      findOne: jest.fn(),
+      ...overrides,
+    })
+
+    it("ne devrait pas notifier si l'invitant est introuvable", async () => {
+      const manager = buildManager()
+      manager.findOne.mockResolvedValueOnce(null).mockResolvedValueOnce({ id: 'invitee-1' }).mockResolvedValueOnce({
+        id: 'resource-1',
+      })
+      const event = { entity: { inviterId: 'inviter-1', inviteeId: 'invitee-1', resourceId: 'resource-1' }, manager }
+
+      await subscriber.afterInsert(event as never)
+
+      expect(notificationService.sendToUser).not.toHaveBeenCalled()
+    })
+
+    it('ne devrait pas notifier si la ressource est introuvable', async () => {
+      const manager = buildManager()
+      manager.findOne
+        .mockResolvedValueOnce({ id: 'inviter-1', username: 'admin' })
+        .mockResolvedValueOnce({ id: 'invitee-1', username: 'student' })
+        .mockResolvedValueOnce(null)
+      const event = { entity: { inviterId: 'inviter-1', inviteeId: 'invitee-1', resourceId: 'resource-1' }, manager }
+
+      await subscriber.afterInsert(event as never)
+
+      expect(notificationService.sendToUser).not.toHaveBeenCalled()
+    })
+
+    it("devrait notifier l'invité quand toutes les entités sont trouvées", async () => {
+      const manager = buildManager()
+      manager.findOne
+        .mockResolvedValueOnce({ id: 'inviter-1', username: 'admin' })
+        .mockResolvedValueOnce({ id: 'invitee-1', username: 'student' })
+        .mockResolvedValueOnce({ id: 'resource-1', name: 'My resource', type: 'CIRCLE' })
+      const event = {
+        entity: { id: 'invitation-1', inviterId: 'inviter-1', inviteeId: 'invitee-1', resourceId: 'resource-1' },
+        manager,
+      }
+
+      await subscriber.afterInsert(event as never)
+
+      expect(notificationService.sendToUser).toHaveBeenCalledWith(
+        'invitee-1',
+        expect.objectContaining({
+          type: 'RESOURCE-INVITATION',
+          inviterName: 'admin',
+          inviteeName: 'student',
+          resourceName: 'My resource',
+        })
+      )
+    })
+  })
+
+  describe('afterRemove', () => {
+    it("ne devrait rien faire si l'entité est absente", async () => {
+      await subscriber.afterRemove({ entity: undefined } as never)
+
+      expect(notificationService.deleteWhere).not.toHaveBeenCalled()
+    })
+
+    it('devrait supprimer les notifications liées à cette invitation', async () => {
+      const invitation = { inviteeId: 'invitee-1', resourceId: 'resource-1' }
+
+      await subscriber.afterRemove({ entity: invitation } as never)
+
+      expect(notificationService.deleteWhere).toHaveBeenCalledWith(
+        'invitee-1',
+        expect.any(Function),
+        expect.any(Function),
+        expect.any(Function)
+      )
+    })
+  })
+})

--- a/libs/feature/resource/server/src/lib/members/member.controller.spec.ts
+++ b/libs/feature/resource/server/src/lib/members/member.controller.spec.ts
@@ -1,0 +1,165 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { ErrorResponse, ForbiddenResponse, UserRoles } from '@platon/core/common'
+import { IRequest } from '@platon/core/server'
+import { createUserEntity } from '@platon/core/testing/server'
+import { Optional } from 'typescript-optional'
+import { ResourceMemberController } from './member.controller'
+import { ResourceMemberEntity } from './member.entity'
+import { ResourceMemberService } from './member.service'
+
+describe('ResourceMemberController', () => {
+  let controller: ResourceMemberController
+  let service: jest.Mocked<ResourceMemberService>
+
+  const buildReq = (overrides: Record<string, unknown> = {}): IRequest =>
+    ({ user: createUserEntity({ role: UserRoles.student, ...overrides }) } as unknown as IRequest)
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ResourceMemberController],
+      providers: [
+        {
+          provide: ResourceMemberService,
+          useValue: {
+            search: jest.fn(),
+            findByUserId: jest.fn(),
+            findAllByUserId: jest.fn(),
+            create: jest.fn(),
+            updateByUserId: jest.fn(),
+            deleteByUserId: jest.fn(),
+          },
+        },
+      ],
+    }).compile()
+
+    controller = module.get(ResourceMemberController)
+    service = module.get(ResourceMemberService)
+  })
+
+  describe('search', () => {
+    it('devrait retourner les membres mappés avec le total', async () => {
+      service.search.mockResolvedValue([[{ resourceId: 'resource-1' } as ResourceMemberEntity], 1])
+
+      const result = await controller.search('resource-1', {})
+
+      expect(service.search).toHaveBeenCalledWith('resource-1', {})
+      expect(result.total).toBe(1)
+    })
+  })
+
+  describe('find', () => {
+    it('devrait rejeter si le membre est introuvable', async () => {
+      service.findByUserId.mockResolvedValue(Optional.empty())
+
+      await expect(controller.find('user-1', 'resource-1')).rejects.toBeInstanceOf(ErrorResponse)
+    })
+
+    it('devrait retourner le membre mappé', async () => {
+      service.findByUserId.mockResolvedValue(
+        Optional.of({ resourceId: 'resource-1', userId: 'user-1' } as ResourceMemberEntity)
+      )
+
+      const result = await controller.find('user-1', 'resource-1')
+
+      expect(result.resource).toBeDefined()
+    })
+  })
+
+  describe('post', () => {
+    it("devrait créer une demande d'adhésion en attente pour l'utilisateur courant", async () => {
+      const req = buildReq()
+      service.create.mockResolvedValue({ resourceId: 'resource-1', userId: req.user.id } as ResourceMemberEntity)
+
+      await controller.post(req, 'resource-1')
+
+      expect(service.create).toHaveBeenCalledWith(
+        expect.objectContaining({ resourceId: 'resource-1', userId: req.user.id, waiting: true })
+      )
+    })
+  })
+
+  describe('autoJoin', () => {
+    it("devrait rejeter un enseignant qui n'est pas nouveau", async () => {
+      const req = buildReq({
+        role: UserRoles.teacher,
+        lastLogin: new Date('2024-01-02'),
+        firstLogin: new Date('2024-01-01'),
+      })
+      service.findAllByUserId.mockResolvedValue([])
+
+      await expect(controller.autoJoin(req, 'resource-1')).rejects.toBeInstanceOf(ForbiddenResponse)
+    })
+
+    it("devrait rejeter un enseignant déjà membre d'une autre ressource", async () => {
+      const sameDate = new Date('2024-01-01')
+      const req = buildReq({ role: UserRoles.teacher, lastLogin: sameDate, firstLogin: sameDate })
+      service.findAllByUserId.mockResolvedValue([{ resourceId: 'other' } as ResourceMemberEntity])
+
+      await expect(controller.autoJoin(req, 'resource-1')).rejects.toBeInstanceOf(ForbiddenResponse)
+    })
+
+    it('devrait auto-rejoindre un enseignant nouvellement créé sans adhésion existante', async () => {
+      const sameDate = new Date('2024-01-01')
+      const req = buildReq({ role: UserRoles.teacher, lastLogin: sameDate, firstLogin: sameDate })
+      service.findAllByUserId.mockResolvedValue([])
+      service.create.mockResolvedValue({ resourceId: 'resource-1', userId: req.user.id, waiting: false } as never)
+
+      const result = await controller.autoJoin(req, 'resource-1')
+
+      expect(service.create).toHaveBeenCalledWith(
+        expect.objectContaining({ waiting: false, permissions: { read: true, write: true } })
+      )
+      expect(result.resource).toBeDefined()
+    })
+  })
+
+  describe('update', () => {
+    it('devrait définir inviterId quand waiting passe explicitement à false', async () => {
+      const req = buildReq({ id: 'admin-1' })
+      service.updateByUserId.mockResolvedValue({} as ResourceMemberEntity)
+
+      await controller.update(req, 'user-1', 'resource-1', { waiting: false })
+
+      expect(service.updateByUserId).toHaveBeenCalledWith('resource-1', 'user-1', {
+        waiting: false,
+        inviterId: 'admin-1',
+      })
+    })
+
+    it("ne devrait pas définir inviterId si waiting n'est pas fourni", async () => {
+      const req = buildReq()
+      service.updateByUserId.mockResolvedValue({} as ResourceMemberEntity)
+
+      await controller.update(req, 'user-1', 'resource-1', { permissions: { read: true, write: false } })
+
+      expect(service.updateByUserId).toHaveBeenCalledWith('resource-1', 'user-1', {
+        permissions: { read: true, write: false },
+      })
+    })
+  })
+
+  describe('delete', () => {
+    it("devrait rejeter si l'utilisateur n'est ni lui-même ni admin", async () => {
+      const req = buildReq({ id: 'user-2', role: UserRoles.student })
+
+      await expect(controller.delete(req, 'user-1', 'resource-1')).rejects.toBeInstanceOf(ForbiddenResponse)
+      expect(service.deleteByUserId).not.toHaveBeenCalled()
+    })
+
+    it('devrait autoriser un utilisateur à se retirer lui-même', async () => {
+      const req = buildReq({ id: 'user-1', role: UserRoles.student })
+
+      await controller.delete(req, 'user-1', 'resource-1')
+
+      expect(service.deleteByUserId).toHaveBeenCalledWith('resource-1', 'user-1')
+    })
+
+    it('devrait autoriser un admin à retirer un autre membre', async () => {
+      const req = buildReq({ id: 'admin-1', role: UserRoles.admin })
+
+      await controller.delete(req, 'user-1', 'resource-1')
+
+      expect(service.deleteByUserId).toHaveBeenCalledWith('resource-1', 'user-1')
+    })
+  })
+})

--- a/libs/feature/resource/server/src/lib/members/member.service.spec.ts
+++ b/libs/feature/resource/server/src/lib/members/member.service.spec.ts
@@ -1,0 +1,177 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { getRepositoryToken } from '@nestjs/typeorm'
+import { BadRequestResponse, NotFoundResponse, UserOrderings } from '@platon/core/common'
+import { MockRepository, mockRepository, mockSelectQueryBuilder } from '@platon/core/testing/server'
+import { EntityManager } from 'typeorm'
+import { ResourceMemberEntity } from './member.entity'
+import { ResourceMemberService } from './member.service'
+
+describe('ResourceMemberService', () => {
+  let service: ResourceMemberService
+  let repository: MockRepository<ResourceMemberEntity>
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ResourceMemberService,
+        { provide: getRepositoryToken(ResourceMemberEntity), useValue: mockRepository<ResourceMemberEntity>() },
+      ],
+    }).compile()
+
+    service = module.get(ResourceMemberService)
+    repository = module.get(getRepositoryToken(ResourceMemberEntity))
+  })
+
+  describe('findByUserId', () => {
+    it('devrait retourner Optional.of(member) si trouvé', async () => {
+      const member = { resourceId: 'resource-1', userId: 'user-1' } as ResourceMemberEntity
+      repository.findOne.mockResolvedValue(member)
+
+      const result = await service.findByUserId('resource-1', 'user-1')
+
+      expect(result.get()).toBe(member)
+    })
+
+    it('devrait retourner Optional.empty() si non trouvé', async () => {
+      repository.findOne.mockResolvedValue(null)
+
+      const result = await service.findByUserId('resource-1', 'unknown')
+
+      expect(result.isPresent()).toBe(false)
+    })
+  })
+
+  describe('findAllByUserId', () => {
+    it("devrait retourner toutes les adhésions de l'utilisateur", async () => {
+      const memberships = [{ resourceId: 'resource-1' } as ResourceMemberEntity]
+      repository.find.mockResolvedValue(memberships)
+
+      const result = await service.findAllByUserId('user-1')
+
+      expect(repository.find).toHaveBeenCalledWith({ where: { userId: 'user-1' } })
+      expect(result).toBe(memberships)
+    })
+  })
+
+  describe('search', () => {
+    it('devrait filtrer par ressource et trier par nom par défaut', async () => {
+      const qb = mockSelectQueryBuilder<ResourceMemberEntity>()
+      repository.createQueryBuilder.mockReturnValue(qb)
+
+      await service.search('resource-1')
+
+      expect(qb.where).toHaveBeenCalledWith('resource_id = :resourceId', { resourceId: 'resource-1' })
+      expect(qb.orderBy).toHaveBeenCalledWith('user.last_name', 'ASC')
+    })
+
+    it('devrait filtrer par texte de recherche avec f_unaccent', async () => {
+      const qb = mockSelectQueryBuilder<ResourceMemberEntity>()
+      repository.createQueryBuilder.mockReturnValue(qb)
+
+      await service.search('resource-1', { search: '  jean  ' })
+
+      expect(qb.andWhere).toHaveBeenCalledWith(expect.stringContaining('f_unaccent'), { search: '%jean%' })
+    })
+
+    it('devrait filtrer par statut waiting', async () => {
+      const qb = mockSelectQueryBuilder<ResourceMemberEntity>()
+      repository.createQueryBuilder.mockReturnValue(qb)
+
+      await service.search('resource-1', { waiting: true })
+
+      expect(qb.andWhere).toHaveBeenCalledWith('member.waiting = :waiting', { waiting: true })
+    })
+
+    it('devrait trier sur un autre champ que NAME sans addOrderBy', async () => {
+      const qb = mockSelectQueryBuilder<ResourceMemberEntity>()
+      repository.createQueryBuilder.mockReturnValue(qb)
+
+      await service.search('resource-1', { order: UserOrderings.CREATED_AT })
+
+      expect(qb.orderBy).toHaveBeenCalledWith('member.created_at', 'DESC')
+      expect(qb.addOrderBy).not.toHaveBeenCalled()
+    })
+
+    it('devrait appliquer offset et limit', async () => {
+      const qb = mockSelectQueryBuilder<ResourceMemberEntity>()
+      repository.createQueryBuilder.mockReturnValue(qb)
+
+      await service.search('resource-1', { offset: 5, limit: 10 })
+
+      expect(qb.offset).toHaveBeenCalledWith(5)
+      expect(qb.limit).toHaveBeenCalledWith(10)
+    })
+  })
+
+  describe('create', () => {
+    it('devrait rejeter avec BadRequestResponse si une adhésion existe déjà', async () => {
+      repository.findOne.mockResolvedValue({ resourceId: 'resource-1', userId: 'user-1' } as ResourceMemberEntity)
+
+      await expect(service.create({ resourceId: 'resource-1', userId: 'user-1' })).rejects.toBeInstanceOf(
+        BadRequestResponse
+      )
+    })
+
+    it("devrait créer l'adhésion si aucune n'existe déjà", async () => {
+      repository.findOne.mockResolvedValue(null)
+      const created = { resourceId: 'resource-1', userId: 'user-1' } as ResourceMemberEntity
+      repository.create.mockReturnValue(created)
+      repository.save.mockResolvedValue(created)
+
+      const result = await service.create({ resourceId: 'resource-1', userId: 'user-1' })
+
+      expect(result).toBe(created)
+    })
+
+    it("devrait utiliser l'EntityManager fourni plutôt que le repository", async () => {
+      const created = { resourceId: 'resource-1', userId: 'user-1' } as ResourceMemberEntity
+      const manager = {
+        findOne: jest.fn().mockResolvedValue(null),
+        create: jest.fn().mockReturnValue(created),
+        save: jest.fn().mockResolvedValue(created),
+      } as unknown as EntityManager
+
+      const result = await service.create({ resourceId: 'resource-1', userId: 'user-1' }, manager)
+
+      expect(repository.findOne).not.toHaveBeenCalled()
+      expect(result).toBe(created)
+    })
+  })
+
+  describe('updateByUserId', () => {
+    it("devrait rejeter avec NotFoundResponse si l'adhésion n'existe pas", async () => {
+      repository.findOne.mockResolvedValue(null)
+
+      await expect(service.updateByUserId('resource-1', 'user-1', { waiting: false })).rejects.toBeInstanceOf(
+        NotFoundResponse
+      )
+    })
+
+    it('devrait fusionner les changements et sauvegarder', async () => {
+      const member = { resourceId: 'resource-1', userId: 'user-1', waiting: true } as ResourceMemberEntity
+      repository.findOne.mockResolvedValue(member)
+      repository.save.mockImplementation(async (m) => m as ResourceMemberEntity)
+
+      const result = await service.updateByUserId('resource-1', 'user-1', { waiting: false })
+
+      expect(result.waiting).toBe(false)
+    })
+  })
+
+  describe('deleteByUserId', () => {
+    it("devrait rejeter avec NotFoundResponse si l'adhésion n'existe pas", async () => {
+      repository.findOne.mockResolvedValue(null)
+
+      await expect(service.deleteByUserId('resource-1', 'user-1')).rejects.toBeInstanceOf(NotFoundResponse)
+    })
+
+    it("devrait supprimer l'adhésion trouvée", async () => {
+      const member = { resourceId: 'resource-1', userId: 'user-1' } as ResourceMemberEntity
+      repository.findOne.mockResolvedValue(member)
+
+      await service.deleteByUserId('resource-1', 'user-1')
+
+      expect(repository.remove).toHaveBeenCalledWith(member)
+    })
+  })
+})

--- a/libs/feature/resource/server/src/lib/members/member.service.ts
+++ b/libs/feature/resource/server/src/lib/members/member.service.ts
@@ -51,7 +51,7 @@ export class ResourceMemberService {
 
     const order = filters.order || UserOrderings.NAME
     const direction = filters.direction || USER_ORDERING_DIRECTIONS[order]
-    if (filters.order === UserOrderings.NAME) {
+    if (order === UserOrderings.NAME) {
       query
         .orderBy('user.last_name', direction)
         .addOrderBy('user.first_name', direction)

--- a/libs/feature/resource/server/src/lib/members/member.subscriber.spec.ts
+++ b/libs/feature/resource/server/src/lib/members/member.subscriber.spec.ts
@@ -1,0 +1,136 @@
+import { ResourceEventTypes } from '@platon/feature/resource/common'
+import { DataSource } from 'typeorm'
+import { ResourceMemberSubscriber } from './member.subscriber'
+
+describe('ResourceMemberSubscriber', () => {
+  let subscriber: ResourceMemberSubscriber
+  let dataSource: { subscribers: unknown[] }
+
+  const buildManager = (overrides: Record<string, unknown> = {}) => ({
+    findOne: jest.fn(),
+    save: jest.fn().mockResolvedValue(undefined),
+    delete: jest.fn().mockResolvedValue(undefined),
+    create: jest.fn((_entity: unknown, data: unknown) => data),
+    ...overrides,
+  })
+
+  beforeEach(() => {
+    dataSource = { subscribers: [] }
+    subscriber = new ResourceMemberSubscriber(dataSource as unknown as DataSource)
+  })
+
+  it("devrait s'enregistrer auprès du DataSource", () => {
+    expect(dataSource.subscribers).toContain(subscriber)
+  })
+
+  describe('afterInsert', () => {
+    it('ne devrait rien faire si la ressource associée est introuvable', async () => {
+      const manager = buildManager()
+      manager.findOne.mockResolvedValue(null)
+      const event = { entity: { resourceId: 'r1', userId: 'u1', waiting: true }, manager }
+
+      await subscriber.afterInsert(event as never)
+
+      expect(manager.save).not.toHaveBeenCalled()
+    })
+
+    it("devrait journaliser l'adhésion et créer un watcher si l'utilisateur est en attente et n'observe pas déjà", async () => {
+      const manager = buildManager()
+      manager.findOne
+        .mockResolvedValueOnce({ id: 'r1', name: 'Resource 1', type: 'CIRCLE' })
+        .mockResolvedValueOnce(null)
+      const event = { entity: { resourceId: 'r1', userId: 'u1', waiting: true, inviterId: 'admin-1' }, manager }
+
+      await subscriber.afterInsert(event as never)
+
+      const savedEntities = manager.save.mock.calls[0][0]
+      expect(savedEntities).toHaveLength(2)
+      expect(savedEntities[0]).toMatchObject({ type: ResourceEventTypes.MEMBER_CREATE })
+    })
+
+    it("ne devrait pas créer de watcher si l'utilisateur observe déjà la ressource", async () => {
+      const manager = buildManager()
+      manager.findOne
+        .mockResolvedValueOnce({ id: 'r1', name: 'Resource 1', type: 'CIRCLE' })
+        .mockResolvedValueOnce({ resourceId: 'r1', userId: 'u1' })
+      const event = { entity: { resourceId: 'r1', userId: 'u1', waiting: true, inviterId: 'admin-1' }, manager }
+
+      await subscriber.afterInsert(event as never)
+
+      const savedEntities = manager.save.mock.calls[0][0]
+      expect(savedEntities).toHaveLength(1)
+    })
+
+    it("ne devrait pas créer de watcher si l'adhésion n'est pas en attente", async () => {
+      const manager = buildManager()
+      manager.findOne
+        .mockResolvedValueOnce({ id: 'r1', name: 'Resource 1', type: 'CIRCLE' })
+        .mockResolvedValueOnce(null)
+      const event = { entity: { resourceId: 'r1', userId: 'u1', waiting: false, inviterId: 'admin-1' }, manager }
+
+      await subscriber.afterInsert(event as never)
+
+      const savedEntities = manager.save.mock.calls[0][0]
+      expect(savedEntities).toHaveLength(1)
+    })
+  })
+
+  describe('afterUpdate', () => {
+    it("ne devrait rien faire si la colonne waiting n'a pas changé", async () => {
+      const manager = buildManager()
+      const event = { entity: { resourceId: 'r1' }, updatedColumns: [{ propertyName: 'permissions' }], manager }
+
+      await subscriber.afterUpdate(event as never)
+
+      expect(manager.findOne).not.toHaveBeenCalled()
+    })
+
+    it('devrait journaliser le changement quand waiting change et que la ressource existe', async () => {
+      const manager = buildManager()
+      manager.findOne
+        .mockResolvedValueOnce({ id: 'r1', name: 'Resource 1', type: 'CIRCLE' })
+        .mockResolvedValueOnce(null)
+      const event = {
+        entity: { resourceId: 'r1', userId: 'u1', waiting: false, inviterId: 'admin-1' },
+        updatedColumns: [{ propertyName: 'waiting' }],
+        manager,
+      }
+
+      await subscriber.afterUpdate(event as never)
+
+      expect(manager.save).toHaveBeenCalled()
+    })
+  })
+
+  describe('afterRemove', () => {
+    it("ne devrait rien faire si l'entité est absente", async () => {
+      const manager = buildManager()
+      const event = { entity: undefined, manager }
+
+      await subscriber.afterRemove(event as never)
+
+      expect(manager.save).not.toHaveBeenCalled()
+    })
+
+    it('devrait supprimer le watcher associé et journaliser le départ si la ressource existe', async () => {
+      const manager = buildManager()
+      manager.findOne.mockResolvedValue({ id: 'r1', name: 'Resource 1', type: 'CIRCLE', parentId: 'parent-1' })
+      const event = { entity: { resourceId: 'r1', userId: 'u1' }, manager }
+
+      await subscriber.afterRemove(event as never)
+
+      expect(manager.delete).toHaveBeenCalledWith(expect.anything(), { resourceId: 'r1', userId: 'u1' })
+      expect(manager.save).toHaveBeenCalledWith(expect.objectContaining({ type: ResourceEventTypes.MEMBER_REMOVE }))
+    })
+
+    it("ne devrait pas journaliser si la ressource n'existe plus", async () => {
+      const manager = buildManager()
+      manager.findOne.mockResolvedValue(null)
+      const event = { entity: { resourceId: 'r1', userId: 'u1' }, manager }
+
+      await subscriber.afterRemove(event as never)
+
+      expect(manager.save).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/libs/feature/resource/server/src/lib/metadata/metadata.service.spec.ts
+++ b/libs/feature/resource/server/src/lib/metadata/metadata.service.spec.ts
@@ -1,0 +1,251 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { getRepositoryToken } from '@nestjs/typeorm'
+import { MockRepository, mockRepository } from '@platon/core/testing/server'
+import { ResourceTypes } from '@platon/feature/resource/common'
+import { EntityManager } from 'typeorm'
+import { ResourceDependencyService } from '../dependency'
+import { ResourceFileService } from '../files/file.service'
+import { ResourceEntity } from '../resource.entity'
+import { ResourceMetaEntity } from './metadata.entity'
+import { ResourceMetadataService } from './metadata.service'
+
+describe('ResourceMetadataService', () => {
+  let service: ResourceMetadataService
+  let repository: MockRepository<ResourceMetaEntity>
+  let fileService: jest.Mocked<ResourceFileService>
+  let dependencyService: jest.Mocked<ResourceDependencyService>
+
+  const buildResource = (overrides: Partial<ResourceEntity> = {}): ResourceEntity =>
+    ({ id: 'resource-1', type: ResourceTypes.CIRCLE, ...overrides } as ResourceEntity)
+
+  const buildRepo = (overrides: Record<string, unknown> = {}) => ({
+    versions: jest.fn().mockResolvedValue({ all: [], latest: undefined }),
+    read: jest.fn(),
+    exists: jest.fn().mockResolvedValue(false),
+    rename: jest.fn().mockResolvedValue(undefined),
+    ...overrides,
+  })
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ResourceMetadataService,
+        { provide: getRepositoryToken(ResourceMetaEntity), useValue: mockRepository<ResourceMetaEntity>() },
+        { provide: ResourceFileService, useValue: { repo: jest.fn() } },
+        { provide: ResourceDependencyService, useValue: { fromActivity: jest.fn(), upsert: jest.fn() } },
+      ],
+    }).compile()
+
+    service = module.get(ResourceMetadataService)
+    repository = module.get(getRepositoryToken(ResourceMetaEntity))
+    fileService = module.get(ResourceFileService)
+    dependencyService = module.get(ResourceDependencyService)
+  })
+
+  describe('findByIds', () => {
+    it('devrait indexer les métadonnées par resourceId', async () => {
+      const metas = [{ resourceId: 'r1' }, { resourceId: 'r2' }] as ResourceMetaEntity[]
+      repository.findBy.mockResolvedValue(metas)
+
+      const result = await service.findByIds(['r1', 'r2'])
+
+      expect(result.get('r1')).toBe(metas[0])
+      expect(result.get('r2')).toBe(metas[1])
+    })
+
+    it('devrait retourner une map vide si la requête échoue', async () => {
+      repository.findBy.mockRejectedValue(new Error('db error'))
+
+      const result = await service.findByIds(['r1'])
+
+      expect(result.size).toBe(0)
+    })
+  })
+
+  describe('of', () => {
+    it('devrait retourner les métadonnées existantes sans les recréer', async () => {
+      const existing = { resourceId: 'resource-1' } as ResourceMetaEntity
+      repository.findOne.mockResolvedValue(existing)
+
+      const result = await service.of('resource-1')
+
+      expect(repository.save).not.toHaveBeenCalled()
+      expect(result).toBe(existing)
+    })
+
+    it("devrait créer les métadonnées si elles n'existent pas encore", async () => {
+      repository.findOne.mockResolvedValue(null)
+      const created = { resourceId: 'resource-1' } as ResourceMetaEntity
+      repository.create.mockReturnValue(created)
+      repository.save.mockResolvedValue(created)
+
+      const result = await service.of('resource-1')
+
+      expect(repository.create).toHaveBeenCalledWith({ resourceId: 'resource-1' })
+      expect(result).toBe(created)
+    })
+
+    it("devrait utiliser l'EntityManager fourni plutôt que le repository", async () => {
+      const created = { resourceId: 'resource-1' } as ResourceMetaEntity
+      const entityManager = {
+        findOne: jest.fn().mockResolvedValue(null),
+        create: jest.fn().mockReturnValue(created),
+        save: jest.fn().mockResolvedValue(created),
+      } as unknown as EntityManager
+
+      const result = await service.of('resource-1', entityManager)
+
+      expect(repository.findOne).not.toHaveBeenCalled()
+      expect(result).toBe(created)
+    })
+  })
+
+  describe('syncCircle', () => {
+    it('devrait synchroniser les versions du circle et sauvegarder', async () => {
+      const resource = buildResource()
+      const repo = buildRepo({ versions: jest.fn().mockResolvedValue({ all: [{ tag: 'v1' }] }) })
+      repository.findOne.mockResolvedValue({ resourceId: 'resource-1' } as ResourceMetaEntity)
+      repository.save.mockImplementation(async (m) => m as ResourceMetaEntity)
+
+      const result = await service.syncCircle({ resource, repo: repo as never })
+
+      expect(fileService.repo).not.toHaveBeenCalled()
+      expect(result.meta).toEqual({ versions: [{ tag: 'v1' }] })
+    })
+
+    it('devrait récupérer le repo via fileService si non fourni', async () => {
+      const resource = buildResource()
+      const repo = buildRepo()
+      fileService.repo.mockResolvedValue({ repo } as never)
+      repository.findOne.mockResolvedValue({ resourceId: 'resource-1' } as ResourceMetaEntity)
+      repository.save.mockImplementation(async (m) => m as ResourceMetaEntity)
+
+      await service.syncCircle({ resource })
+
+      expect(fileService.repo).toHaveBeenCalledWith(resource)
+    })
+  })
+
+  describe('syncActivity', () => {
+    it('devrait extraire les settings, synchroniser les dépendances et sauvegarder', async () => {
+      const resource = buildResource({ type: ResourceTypes.ACTIVITY })
+      const content = JSON.stringify({ settings: { navigation: { mode: 'linear' } }, exerciseGroups: {} })
+      const repo = buildRepo({
+        read: jest.fn().mockResolvedValue([{}, Promise.resolve({ buffer: Buffer.from(content) })]),
+        versions: jest.fn().mockResolvedValue({ all: [{ tag: 'v1' }] }),
+      })
+      repository.findOne.mockResolvedValue({ resourceId: 'resource-1' } as ResourceMetaEntity)
+      repository.save.mockImplementation(async (m) => m as ResourceMetaEntity)
+
+      const result = await service.syncActivity({ resource, repo: repo as never })
+
+      expect(dependencyService.fromActivity).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'resource-1', exerciseGroups: {} })
+      )
+      expect((result.meta as never as { settings: unknown }).settings).toEqual({ navigation: { mode: 'linear' } })
+    })
+  })
+
+  describe('syncExercise', () => {
+    it('devrait renommer un ancien config.json', async () => {
+      const resource = buildResource({ type: ResourceTypes.EXERCISE })
+      const repo = buildRepo({ exists: jest.fn().mockResolvedValue(false) })
+      repo.exists.mockImplementation((path: string) => Promise.resolve(path === 'config.json'))
+      repository.findOne.mockResolvedValue({ resourceId: 'resource-1' } as ResourceMetaEntity)
+      repository.save.mockImplementation(async (m) => m as ResourceMetaEntity)
+
+      await service.syncExercise({ resource, repo: repo as never })
+
+      expect(repo.rename).toHaveBeenCalledWith('config.json', expect.any(String))
+    })
+
+    it('devrait marquer configurable=false si aucun fichier de config ple ne existe', async () => {
+      const resource = buildResource({ type: ResourceTypes.EXERCISE })
+      const repo = buildRepo({ exists: jest.fn().mockResolvedValue(false) })
+      repository.findOne.mockResolvedValue({ resourceId: 'resource-1' } as ResourceMetaEntity)
+      repository.save.mockImplementation(async (m) => m as ResourceMetaEntity)
+
+      const result = await service.syncExercise({ resource, repo: repo as never })
+
+      expect((result.meta as never as { configurable: boolean }).configurable).toBe(false)
+    })
+
+    it('devrait lire la config existante et calculer configurable selon le nombre de champs', async () => {
+      const resource = buildResource({ type: ResourceTypes.EXERCISE })
+      const config = { inputs: [{ name: 'x' }] }
+      const repo = buildRepo({
+        exists: jest.fn().mockResolvedValue(true),
+        read: jest.fn().mockResolvedValue([{}, Promise.resolve({ buffer: Buffer.from(JSON.stringify(config)) })]),
+      })
+      repository.findOne.mockResolvedValue({ resourceId: 'resource-1' } as ResourceMetaEntity)
+      repository.save.mockImplementation(async (m) => m as ResourceMetaEntity)
+
+      const result = await service.syncExercise({ resource, repo: repo as never })
+
+      expect((result.meta as never as { configurable: boolean }).configurable).toBe(true)
+    })
+
+    it('devrait utiliser le contenu du changement fourni plutôt que relire le fichier', async () => {
+      const resource = buildResource({ type: ResourceTypes.EXERCISE })
+      const repo = buildRepo({ exists: jest.fn().mockResolvedValue(true) })
+      repository.findOne.mockResolvedValue({ resourceId: 'resource-1' } as ResourceMetaEntity)
+      repository.save.mockImplementation(async (m) => m as ResourceMetaEntity)
+
+      await service.syncExercise({ resource, repo: repo as never }, {
+        path: 'ple.config.json',
+        newContent: JSON.stringify({ inputs: [] }),
+      } as never)
+
+      expect(repo.read).not.toHaveBeenCalled()
+    })
+
+    it('devrait upsert la dépendance de template si templateId est défini', async () => {
+      const resource = buildResource({ type: ResourceTypes.EXERCISE, templateId: 'template-1' } as never)
+      const repo = buildRepo()
+      repository.findOne.mockResolvedValue({ resourceId: 'resource-1' } as ResourceMetaEntity)
+      repository.save.mockImplementation(async (m) => m as ResourceMetaEntity)
+
+      await service.syncExercise({ resource, repo: repo as never })
+
+      expect(dependencyService.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({ resourceId: 'resource-1', dependOnId: 'template-1', isTemplate: true })
+      )
+    })
+  })
+
+  describe('onReleaseRepo', () => {
+    it('devrait synchroniser selon le type de ressource sans laisser fuiter les erreurs', async () => {
+      const resource = buildResource({ type: ResourceTypes.CIRCLE })
+      const repo = buildRepo()
+      repository.findOne.mockResolvedValue({ resourceId: 'resource-1' } as ResourceMetaEntity)
+      repository.save.mockRejectedValue(new Error('save failed'))
+
+      await expect(
+        (service as never as { onReleaseRepo: (p: unknown) => Promise<void> }).onReleaseRepo({
+          repo,
+          resource,
+        })
+      ).resolves.toBeUndefined()
+    })
+  })
+
+  describe('onCreateResource', () => {
+    it('devrait upsert la dépendance de template si templateId est défini, sans laisser fuiter les erreurs', async () => {
+      const resource = buildResource({ templateId: 'template-1' } as never)
+
+      await (service as never as { onCreateResource: (p: unknown) => Promise<void> }).onCreateResource({ resource })
+
+      expect(dependencyService.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({ resourceId: 'resource-1', dependOnId: 'template-1' })
+      )
+    })
+
+    it('ne devrait rien faire si templateId est absent', async () => {
+      const resource = buildResource()
+
+      await (service as never as { onCreateResource: (p: unknown) => Promise<void> }).onCreateResource({ resource })
+
+      expect(dependencyService.upsert).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/libs/feature/resource/server/src/lib/permissions/permissions.service.spec.ts
+++ b/libs/feature/resource/server/src/lib/permissions/permissions.service.spec.ts
@@ -1,0 +1,247 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { IRequest } from '@platon/core/server'
+import { UserRoles } from '@platon/core/common'
+import { createUserEntity } from '@platon/core/testing/server'
+import { ResourceMember, ResourceTypes } from '@platon/feature/resource/common'
+import { ResourceMemberEntity, ResourceMemberService } from '../members'
+import { ResourceEntity } from '../resource.entity'
+import { ResourceService } from '../resource.service'
+import { ResourceWatcherEntity, ResourceWatcherService } from '../watchers'
+import { ResourcePermissionService } from './permissions.service'
+
+describe('ResourcePermissionService', () => {
+  let service: ResourcePermissionService
+  let memberService: jest.Mocked<ResourceMemberService>
+  let watcherService: jest.Mocked<ResourceWatcherService>
+  let resourceService: jest.Mocked<ResourceService>
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ResourcePermissionService,
+        { provide: ResourceMemberService, useValue: { findAllByUserId: jest.fn().mockResolvedValue([]) } },
+        { provide: ResourceWatcherService, useValue: { findAllByUserId: jest.fn().mockResolvedValue([]) } },
+        {
+          provide: ResourceService,
+          useValue: {
+            getById: jest.fn(),
+            getDescendants: jest.fn().mockResolvedValue([]),
+            getParents: jest.fn().mockResolvedValue([]),
+          },
+        },
+      ],
+    }).compile()
+
+    service = module.get(ResourcePermissionService)
+    memberService = module.get(ResourceMemberService)
+    watcherService = module.get(ResourceWatcherService)
+    resourceService = module.get(ResourceService)
+  })
+
+  const buildCircle = (overrides: Partial<ResourceEntity> = {}): ResourceEntity =>
+    ({
+      id: 'circle-1',
+      type: ResourceTypes.CIRCLE,
+      personal: false,
+      ownerId: 'owner-1',
+      ...overrides,
+    } as ResourceEntity)
+
+  const buildReq = (user: ReturnType<typeof createUserEntity>): IRequest =>
+    ({ user, memoize: jest.fn(async (_key: string, fn: () => Promise<unknown>) => fn()) } as unknown as IRequest)
+
+  const buildMembership = (overrides: Partial<ResourceMember> = {}): ResourceMemberEntity =>
+    ({ resourceId: 'circle-1', userId: 'user-1', waiting: false, ...overrides } as ResourceMemberEntity)
+
+  describe('userPermissionsOnResource', () => {
+    it("devrait retourner des permissions vides si la requête n'a pas d'utilisateur", async () => {
+      const result = await service.userPermissionsOnResource({ resource: buildCircle(), req: undefined })
+
+      expect(result).toEqual({ read: false, write: false, member: false, watcher: false, waiting: false })
+    })
+
+    it('devrait autoriser la lecture sur un cercle non personnel sans condition', async () => {
+      const user = createUserEntity({ id: 'stranger', role: UserRoles.student })
+      const circle = buildCircle({ personal: false })
+      const req = buildReq(user)
+
+      const result = await service.userPermissionsOnResource({ req, resource: circle })
+
+      expect(result.read).toBe(true)
+    })
+
+    describe('lecture sur un cercle personnel', () => {
+      it('devrait autoriser le propriétaire', async () => {
+        const owner = createUserEntity({ id: 'owner-1', role: UserRoles.student })
+        const circle = buildCircle({ personal: true, ownerId: 'owner-1' })
+        const req = buildReq(owner)
+
+        const result = await service.userPermissionsOnResource({ req, resource: circle })
+
+        expect(result.read).toBe(true)
+      })
+
+      it('devrait autoriser un membre du cercle', async () => {
+        const user = createUserEntity({ id: 'member-1', role: UserRoles.student })
+        memberService.findAllByUserId.mockResolvedValue([buildMembership({ resourceId: 'circle-1' })])
+        const circle = buildCircle({ personal: true, ownerId: 'owner-1' })
+        const req = buildReq(user)
+
+        const result = await service.userPermissionsOnResource({ req, resource: circle })
+
+        expect(result.read).toBe(true)
+      })
+
+      it("devrait autoriser un membre d'un cercle descendant", async () => {
+        const user = createUserEntity({ id: 'member-1', role: UserRoles.student })
+        memberService.findAllByUserId.mockResolvedValue([buildMembership({ resourceId: 'descendant-1' })])
+        resourceService.getDescendants.mockResolvedValue([buildCircle({ id: 'descendant-1' })])
+        const circle = buildCircle({ personal: true, ownerId: 'owner-1' })
+        const req = buildReq(user)
+
+        const result = await service.userPermissionsOnResource({ req, resource: circle })
+
+        expect(result.read).toBe(true)
+      })
+
+      it('devrait refuser un utilisateur sans lien avec le cercle', async () => {
+        const stranger = createUserEntity({ id: 'stranger', role: UserRoles.student })
+        const circle = buildCircle({ personal: true, ownerId: 'owner-1' })
+        const req = buildReq(stranger)
+
+        const result = await service.userPermissionsOnResource({ req, resource: circle })
+
+        expect(result.read).toBe(false)
+      })
+    })
+
+    describe('écriture', () => {
+      it('devrait autoriser le propriétaire du cercle', async () => {
+        const owner = createUserEntity({ id: 'owner-1', role: UserRoles.student })
+        const circle = buildCircle({ ownerId: 'owner-1' })
+        const req = buildReq(owner)
+
+        const result = await service.userPermissionsOnResource({ req, resource: circle })
+
+        expect(result.write).toBe(true)
+      })
+
+      it('devrait autoriser un admin sur un cercle non personnel', async () => {
+        const admin = createUserEntity({ id: 'admin-1', role: UserRoles.admin })
+        const circle = buildCircle({ personal: false, ownerId: 'someone-else' })
+        const req = buildReq(admin)
+
+        const result = await service.userPermissionsOnResource({ req, resource: circle })
+
+        expect(result.write).toBe(true)
+      })
+
+      it('ne devrait pas autoriser un admin sur un cercle personnel via la seule règle admin', async () => {
+        const admin = createUserEntity({ id: 'admin-1', role: UserRoles.admin })
+        const circle = buildCircle({ personal: true, ownerId: 'someone-else' })
+        const req = buildReq(admin)
+
+        const result = await service.userPermissionsOnResource({ req, resource: circle })
+
+        expect(result.write).toBe(false)
+      })
+
+      it('devrait autoriser un membre non-waiting du cercle', async () => {
+        const user = createUserEntity({ id: 'member-1', role: UserRoles.student })
+        memberService.findAllByUserId.mockResolvedValue([buildMembership({ resourceId: 'circle-1', waiting: false })])
+        const circle = buildCircle({ ownerId: 'someone-else' })
+        const req = buildReq(user)
+
+        const result = await service.userPermissionsOnResource({ req, resource: circle })
+
+        expect(result.write).toBe(true)
+      })
+
+      it('ne devrait pas autoriser un membre en attente (waiting) du cercle', async () => {
+        const user = createUserEntity({ id: 'member-1', role: UserRoles.student })
+        memberService.findAllByUserId.mockResolvedValue([buildMembership({ resourceId: 'circle-1', waiting: true })])
+        resourceService.getParents.mockResolvedValue([])
+        const circle = buildCircle({ ownerId: 'someone-else' })
+        const req = buildReq(user)
+
+        const result = await service.userPermissionsOnResource({ req, resource: circle })
+
+        expect(result.write).toBe(false)
+        expect(result.waiting).toBe(true)
+      })
+
+      it("devrait autoriser via l'appartenance à un cercle parent non personnel", async () => {
+        const user = createUserEntity({ id: 'member-1', role: UserRoles.student })
+        const circle = buildCircle({ personal: false, ownerId: 'someone-else' })
+        const parent = buildCircle({ id: 'parent-1', ownerId: 'someone-else' })
+        resourceService.getParents.mockResolvedValue([parent])
+        memberService.findAllByUserId.mockResolvedValue([buildMembership({ resourceId: 'parent-1' })])
+        const req = buildReq(user)
+
+        const result = await service.userPermissionsOnResource({ req, resource: circle })
+
+        expect(result.write).toBe(true)
+      })
+
+      it("ne devrait pas consulter les parents si le cercle est personnel et n'appartient pas à l'utilisateur", async () => {
+        const stranger = createUserEntity({ id: 'stranger', role: UserRoles.student })
+        const circle = buildCircle({ personal: true, ownerId: 'owner-1' })
+        const req = buildReq(stranger)
+
+        const result = await service.userPermissionsOnResource({ req, resource: circle })
+
+        expect(result.write).toBe(false)
+        expect(resourceService.getParents).not.toHaveBeenCalled()
+      })
+    })
+
+    it('devrait résoudre le cercle parent pour une ressource non-cercle', async () => {
+      const user = createUserEntity({ id: 'owner-1', role: UserRoles.student })
+      const exercise = { id: 'exercise-1', type: ResourceTypes.EXERCISE, parentId: 'circle-1' } as ResourceEntity
+      resourceService.getById.mockResolvedValue(buildCircle({ ownerId: 'owner-1' }))
+      const req = buildReq(user)
+
+      const result = await service.userPermissionsOnResource({ req, resource: exercise })
+
+      expect(resourceService.getById).toHaveBeenCalledWith('circle-1', false)
+      expect(result.write).toBe(true)
+    })
+
+    it("devrait indiquer watcher=true si l'utilisateur observe la ressource", async () => {
+      const user = createUserEntity({ id: 'watcher-1', role: UserRoles.student })
+      watcherService.findAllByUserId.mockResolvedValue([{ resourceId: 'circle-1' } as ResourceWatcherEntity])
+      const circle = buildCircle()
+      const req = buildReq(user)
+
+      const result = await service.userPermissionsOnResource({ req, resource: circle })
+
+      expect(result.watcher).toBe(true)
+    })
+
+    it("devrait indiquer member=true si l'utilisateur est membre de la ressource elle-même", async () => {
+      const user = createUserEntity({ id: 'member-1', role: UserRoles.student })
+      memberService.findAllByUserId.mockResolvedValue([buildMembership({ resourceId: 'circle-1' })])
+      const circle = buildCircle()
+      const req = buildReq(user)
+
+      const result = await service.userPermissionsOnResource({ req, resource: circle })
+
+      expect(result.member).toBe(true)
+    })
+  })
+
+  describe('userPermissionsOnResources', () => {
+    it('devrait calculer les permissions pour chaque ressource fournie', async () => {
+      const user = createUserEntity({ id: 'owner-1', role: UserRoles.student })
+      const circle1 = buildCircle({ id: 'circle-1', ownerId: 'owner-1' })
+      const circle2 = buildCircle({ id: 'circle-2', ownerId: 'someone-else', personal: false })
+      const req = buildReq(user)
+
+      const result = await service.userPermissionsOnResources([circle1, circle2], req)
+
+      expect(result).toHaveLength(2)
+      expect(result[0].permissions.write).toBe(true)
+      expect(result[1].permissions.write).toBe(false)
+    })
+  })
+})

--- a/libs/feature/resource/server/src/lib/resource.controller.spec.ts
+++ b/libs/feature/resource/server/src/lib/resource.controller.spec.ts
@@ -1,0 +1,593 @@
+import { InternalServerErrorException } from '@nestjs/common'
+import { Test, TestingModule } from '@nestjs/testing'
+import { BadRequestResponse, ForbiddenResponse, NotFoundResponse, UserRoles } from '@platon/core/common'
+import { IRequest, UserService } from '@platon/core/server'
+import { createUserEntity } from '@platon/core/testing/server'
+import { NotificationService } from '@platon/feature/notification/server'
+import { ResourceStatus, ResourceTypes } from '@platon/feature/resource/common'
+import { Optional } from 'typescript-optional'
+import { ResourceFileService } from './files'
+import { ResourcePermissionService } from './permissions/permissions.service'
+import { ResourceController } from './resource.controller'
+import { ResourceEntity } from './resource.entity'
+import { ResourceService } from './resource.service'
+import { ResourceViewService } from './views/view.service'
+import { ResourceDependencyService } from './dependency'
+
+describe('ResourceController', () => {
+  let controller: ResourceController
+  let resourceService: jest.Mocked<ResourceService>
+  let permissionService: jest.Mocked<ResourcePermissionService>
+  let resourceViewService: jest.Mocked<ResourceViewService>
+  let userService: jest.Mocked<UserService>
+  let notificationService: jest.Mocked<NotificationService>
+  let fileService: jest.Mocked<ResourceFileService>
+  let dependencyService: jest.Mocked<ResourceDependencyService>
+
+  const fullPermissions = { read: true, write: true } as never
+  const readOnlyPermissions = { read: true, write: false } as never
+  const noPermissions = { read: false, write: false } as never
+
+  const buildResource = (overrides: Partial<ResourceEntity> = {}): ResourceEntity =>
+    ({
+      id: 'resource-1',
+      name: 'Resource 1',
+      type: ResourceTypes.CIRCLE,
+      status: ResourceStatus.READY,
+      personal: false,
+      ...overrides,
+    } as ResourceEntity)
+
+  const buildReq = (overrides: Partial<ReturnType<typeof createUserEntity>> = {}): IRequest =>
+    ({ user: createUserEntity({ role: UserRoles.teacher, ...overrides }) } as unknown as IRequest)
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ResourceController],
+      providers: [
+        {
+          provide: ResourceService,
+          useValue: {
+            search: jest.fn(),
+            tree: jest.fn(),
+            getPersonal: jest.fn(),
+            completion: jest.fn(),
+            getAllOwners: jest.fn(),
+            findByIdOrCode: jest.fn(),
+            getById: jest.fn(),
+            create: jest.fn(),
+            fromInput: jest.fn(),
+            update: jest.fn(),
+            move: jest.fn(),
+            delete: jest.fn(),
+            isConfigurableExercise: jest.fn(),
+            updateCertification: jest.fn(),
+          },
+        },
+        {
+          provide: ResourcePermissionService,
+          useValue: { userPermissionsOnResource: jest.fn(), userPermissionsOnResources: jest.fn() },
+        },
+        {
+          provide: ResourceViewService,
+          useValue: { findAll: jest.fn(), create: jest.fn().mockResolvedValue(undefined) },
+        },
+        { provide: UserService, useValue: { findById: jest.fn() } },
+        { provide: NotificationService, useValue: { sendToUser: jest.fn().mockResolvedValue(undefined) } },
+        { provide: ResourceFileService, useValue: { repo: jest.fn(), copy: jest.fn() } },
+        {
+          provide: ResourceDependencyService,
+          useValue: { updateTemplateDependency: jest.fn(), deleteDependencyForVersion: jest.fn() },
+        },
+      ],
+    }).compile()
+
+    controller = module.get(ResourceController)
+    resourceService = module.get(ResourceService)
+    permissionService = module.get(ResourcePermissionService)
+    resourceViewService = module.get(ResourceViewService)
+    userService = module.get(UserService)
+    notificationService = module.get(NotificationService)
+    fileService = module.get(ResourceFileService)
+    dependencyService = module.get(ResourceDependencyService)
+
+    permissionService.userPermissionsOnResource.mockResolvedValue(fullPermissions)
+  })
+
+  describe('search', () => {
+    it('devrait rechercher via ResourceViewService quand filters.views est fourni', async () => {
+      const resource = buildResource()
+      resourceViewService.findAll.mockResolvedValue([[{ resource } as never], 1])
+      const req = buildReq()
+
+      const result = await controller.search(req, { views: true } as never)
+
+      expect(resourceViewService.findAll).toHaveBeenCalledWith(req.user.id)
+      expect(resourceService.search).not.toHaveBeenCalled()
+      expect(result.total).toBe(1)
+    })
+
+    it("devrait rechercher via ResourceService sinon, filtré sur l'utilisateur courant", async () => {
+      resourceService.search.mockResolvedValue([[buildResource()], 1])
+      const req = buildReq()
+
+      const result = await controller.search(req, {})
+
+      expect(resourceService.search).toHaveBeenCalledWith({}, req.user.id)
+      expect(result.total).toBe(1)
+    })
+  })
+
+  describe('tree', () => {
+    it("devrait construire l'arbre, ajouter le cercle personnel et injecter les permissions", async () => {
+      const circle = buildResource({ id: 'circle-1' })
+      const personal = buildResource({ id: 'personal-1' })
+      resourceService.search.mockResolvedValue([[circle], 1])
+      resourceService.getPersonal.mockResolvedValue(personal)
+      resourceService.tree.mockResolvedValue({ id: 'circle-1', children: [] } as never)
+      permissionService.userPermissionsOnResources.mockResolvedValue([
+        { resource: circle, permissions: fullPermissions },
+      ])
+      const req = buildReq()
+
+      const result = await controller.tree(req)
+
+      expect(resourceService.getPersonal).toHaveBeenCalledWith(req.user)
+      expect(result.resource.id).toBe('circle-1')
+    })
+  })
+
+  describe('completion', () => {
+    it('devrait retourner la ressource de complétion mappée', async () => {
+      resourceService.completion.mockResolvedValue({ levels: [], topics: [], names: [] })
+      const req = buildReq()
+
+      const result = await controller.completion(req)
+
+      expect(resourceService.completion).toHaveBeenCalledWith(req.user)
+      expect(result.resource).toBeDefined()
+    })
+  })
+
+  describe('listOwners', () => {
+    it('devrait retourner tous les propriétaires mappés', async () => {
+      const owner = createUserEntity({ username: 'owner1' })
+      resourceService.getAllOwners.mockResolvedValue([owner as never])
+
+      const result = await controller.listOwners()
+
+      expect(result.total).toBe(1)
+      expect(result.resources[0].username).toBe('owner1')
+    })
+  })
+
+  describe('find', () => {
+    it("devrait rejeter avec NotFoundResponse si la ressource n'existe pas", async () => {
+      resourceService.findByIdOrCode.mockResolvedValue(Optional.empty())
+
+      await expect(controller.find(buildReq(), 'unknown')).rejects.toBeInstanceOf(NotFoundResponse)
+    })
+
+    it("devrait rejeter avec ForbiddenResponse si l'utilisateur n'a pas la permission de lecture", async () => {
+      resourceService.findByIdOrCode.mockResolvedValue(Optional.of(buildResource()))
+      permissionService.userPermissionsOnResource.mockResolvedValue(noPermissions)
+
+      await expect(controller.find(buildReq(), 'resource-1')).rejects.toBeInstanceOf(ForbiddenResponse)
+    })
+
+    it('devrait retourner la ressource avec ses permissions', async () => {
+      resourceService.findByIdOrCode.mockResolvedValue(Optional.of(buildResource()))
+
+      const result = await controller.find(buildReq(), 'resource-1')
+
+      expect((result.resource as never as { permissions: unknown }).permissions).toEqual(fullPermissions)
+    })
+
+    it('devrait marquer la ressource comme vue sans bloquer la réponse quand markAsViewed est fourni', async () => {
+      resourceService.findByIdOrCode.mockResolvedValue(Optional.of(buildResource()))
+      const req = buildReq()
+
+      await controller.find(req, 'resource-1', 'true')
+
+      expect(resourceViewService.create).toHaveBeenCalledWith({ resourceId: 'resource-1', userId: req.user.id })
+    })
+  })
+
+  describe('create', () => {
+    it("devrait rejeter avec NotFoundResponse si le parent n'existe pas", async () => {
+      resourceService.findByIdOrCode.mockResolvedValue(Optional.empty())
+
+      await expect(
+        controller.create(buildReq(), { parentId: 'unknown', name: 'New', type: ResourceTypes.CIRCLE } as never)
+      ).rejects.toBeInstanceOf(NotFoundResponse)
+    })
+
+    it("devrait rejeter avec ForbiddenResponse si l'utilisateur n'a pas la permission d'écriture sur le parent", async () => {
+      resourceService.findByIdOrCode.mockResolvedValue(Optional.of(buildResource()))
+      permissionService.userPermissionsOnResource.mockResolvedValue(readOnlyPermissions)
+
+      await expect(
+        controller.create(buildReq(), { parentId: 'parent-1', name: 'New', type: ResourceTypes.CIRCLE } as never)
+      ).rejects.toBeInstanceOf(ForbiddenResponse)
+    })
+
+    it('devrait rejeter si un exercice est créé sans le fichier main.py', async () => {
+      resourceService.findByIdOrCode.mockResolvedValue(Optional.of(buildResource()))
+
+      await expect(
+        controller.create(buildReq(), {
+          parentId: 'parent-1',
+          name: 'New',
+          type: ResourceTypes.EXERCISE,
+          files: [{ path: 'other.py', content: '' }],
+        } as never)
+      ).rejects.toBeInstanceOf(BadRequestResponse)
+    })
+
+    it('devrait créer la ressource et écrire les fichiers fournis', async () => {
+      resourceService.findByIdOrCode.mockResolvedValue(Optional.of(buildResource()))
+      resourceService.fromInput.mockResolvedValue({ name: 'New' } as never)
+      const created = buildResource({ id: 'new-resource' })
+      resourceService.create.mockResolvedValue(created)
+      const req = buildReq()
+
+      const result = await controller.create(req, {
+        parentId: 'parent-1',
+        name: 'New',
+        type: ResourceTypes.CIRCLE,
+      } as never)
+
+      expect(resourceService.create).toHaveBeenCalledWith(expect.objectContaining({ ownerId: req.user.id }))
+      expect(result.resource.id).toBe('new-resource')
+    })
+  })
+
+  describe('duplicateResource', () => {
+    it("devrait rejeter avec NotFoundResponse si la ressource n'existe pas", async () => {
+      resourceService.findByIdOrCode.mockResolvedValue(Optional.empty())
+
+      await expect(controller.duplicateResource(buildReq(), 'unknown')).rejects.toBeInstanceOf(NotFoundResponse)
+    })
+
+    it('devrait rejeter si le type de ressource ne peut pas être dupliqué', async () => {
+      resourceService.findByIdOrCode.mockResolvedValue(Optional.of(buildResource({ type: ResourceTypes.CIRCLE })))
+
+      await expect(controller.duplicateResource(buildReq(), 'resource-1')).rejects.toBeInstanceOf(BadRequestResponse)
+    })
+
+    it("devrait rejeter avec ForbiddenResponse si l'utilisateur n'a pas accès en lecture", async () => {
+      resourceService.findByIdOrCode.mockResolvedValue(Optional.of(buildResource({ type: ResourceTypes.EXERCISE })))
+      permissionService.userPermissionsOnResource.mockResolvedValue(noPermissions)
+
+      await expect(controller.duplicateResource(buildReq(), 'resource-1')).rejects.toBeInstanceOf(ForbiddenResponse)
+    })
+
+    it('devrait dupliquer la ressource et copier ses fichiers', async () => {
+      const existing = buildResource({ type: ResourceTypes.EXERCISE })
+      resourceService.findByIdOrCode.mockResolvedValue(Optional.of(existing))
+      resourceService.getPersonal.mockResolvedValue(buildResource({ id: 'circle-1' }))
+      const duplicated = buildResource({ id: 'duplicated-1', type: ResourceTypes.EXERCISE })
+      resourceService.create.mockResolvedValue(duplicated)
+
+      const result = await controller.duplicateResource(buildReq(), 'resource-1')
+
+      expect(fileService.copy).toHaveBeenCalledWith('resource-1', 'duplicated-1', expect.anything())
+      expect(result.resource.id).toBe('duplicated-1')
+    })
+
+    it('devrait supprimer la ressource dupliquée si la copie des fichiers échoue', async () => {
+      const existing = buildResource({ type: ResourceTypes.EXERCISE })
+      resourceService.findByIdOrCode.mockResolvedValue(Optional.of(existing))
+      resourceService.getPersonal.mockResolvedValue(buildResource({ id: 'circle-1' }))
+      const duplicated = buildResource({ id: 'duplicated-1', type: ResourceTypes.EXERCISE })
+      resourceService.create.mockResolvedValue(duplicated)
+      fileService.copy.mockRejectedValue(new Error('copy failed'))
+
+      await expect(controller.duplicateResource(buildReq(), 'resource-1')).rejects.toThrow('copy failed')
+      expect(resourceService.delete).toHaveBeenCalledWith(duplicated)
+    })
+  })
+
+  describe('createPreview', () => {
+    it('devrait rejeter si le fichier main.py est manquant', async () => {
+      await expect(
+        controller.createPreview(buildReq(), { files: [{ path: 'other.py', content: '' }] } as never)
+      ).rejects.toBeInstanceOf(BadRequestResponse)
+    })
+
+    it("devrait lever une InternalServerErrorException si l'utilisateur par défaut est introuvable", async () => {
+      userService.findById.mockResolvedValue(Optional.empty())
+
+      await expect(
+        controller.createPreview(buildReq(), { files: [{ path: 'main.ple', content: '' }] } as never)
+      ).rejects.toBeInstanceOf(InternalServerErrorException)
+    })
+
+    it("devrait créer une nouvelle ressource de preview quand aucun resourceId n'est fourni", async () => {
+      userService.findById.mockResolvedValue(Optional.of(createUserEntity() as never))
+      resourceService.getPersonal.mockResolvedValue(buildResource({ id: 'circle-1' }))
+      const created = buildResource({ id: 'preview-1', type: ResourceTypes.EXERCISE })
+      resourceService.create.mockResolvedValue(created)
+      fileService.repo.mockResolvedValue({ repo: { write: jest.fn() } } as never)
+
+      const result = await controller.createPreview(buildReq(), {
+        files: [{ path: 'main.ple', content: 'code' }],
+      } as never)
+
+      expect(resourceService.create).toHaveBeenCalled()
+      expect(result.resource.id).toBe('preview-1')
+    })
+
+    it('devrait réutiliser la ressource existante et réécrire ses fichiers quand resourceId est fourni', async () => {
+      userService.findById.mockResolvedValue(Optional.of(createUserEntity() as never))
+      const existing = buildResource({ id: 'preview-1', type: ResourceTypes.EXERCISE })
+      resourceService.getById.mockResolvedValue(existing)
+      const write = jest.fn()
+      fileService.repo.mockResolvedValue({ repo: { write } } as never)
+
+      await controller.createPreview(buildReq(), {
+        resourceId: 'preview-1',
+        files: [{ path: 'main.ple', content: 'code' }],
+      } as never)
+
+      expect(resourceService.create).not.toHaveBeenCalled()
+      expect(write).toHaveBeenCalledWith('main.ple', 'code')
+    })
+  })
+
+  describe('update', () => {
+    it("devrait rejeter avec NotFoundResponse si la ressource n'existe pas", async () => {
+      resourceService.findByIdOrCode.mockResolvedValue(Optional.empty())
+
+      await expect(controller.update(buildReq(), 'unknown', {} as never)).rejects.toBeInstanceOf(NotFoundResponse)
+    })
+
+    it("devrait rejeter avec ForbiddenResponse si l'utilisateur n'a pas la permission d'écriture", async () => {
+      resourceService.findByIdOrCode.mockResolvedValue(Optional.of(buildResource()))
+      permissionService.userPermissionsOnResource.mockResolvedValue(readOnlyPermissions)
+
+      await expect(controller.update(buildReq(), 'resource-1', {} as never)).rejects.toBeInstanceOf(ForbiddenResponse)
+    })
+
+    it('devrait mettre à jour la ressource', async () => {
+      resourceService.findByIdOrCode.mockResolvedValue(Optional.of(buildResource()))
+      resourceService.fromInput.mockResolvedValue({ name: 'New' } as never)
+      resourceService.update.mockResolvedValue(buildResource({ name: 'New' }))
+
+      const result = await controller.update(buildReq(), 'resource-1', { name: 'New' } as never)
+
+      expect(result.resource.name).toBe('New')
+    })
+  })
+
+  describe('move', () => {
+    it("devrait rejeter avec NotFoundResponse si la ressource n'existe pas", async () => {
+      resourceService.findByIdOrCode.mockResolvedValue(Optional.empty())
+
+      await expect(controller.move(buildReq(), 'unknown', 'parent-1')).rejects.toBeInstanceOf(NotFoundResponse)
+    })
+
+    it("devrait rejeter avec ForbiddenResponse pour un non-admin si le cercle parent n'est pas personnel", async () => {
+      const resource = buildResource({ parentId: 'parent-circle' } as never)
+      const parentCircle = buildResource({ id: 'parent-circle', personal: false })
+      resourceService.findByIdOrCode
+        .mockResolvedValueOnce(Optional.of(resource))
+        .mockResolvedValueOnce(Optional.of(parentCircle))
+
+      await expect(
+        controller.move(buildReq({ role: UserRoles.teacher }), 'resource-1', 'new-parent')
+      ).rejects.toBeInstanceOf(ForbiddenResponse)
+    })
+
+    it("devrait autoriser un admin même si le cercle parent actuel n'est pas personnel", async () => {
+      const resource = buildResource({ parentId: 'parent-circle' } as never)
+      const parentCircle = buildResource({ id: 'parent-circle', personal: false })
+      resourceService.findByIdOrCode
+        .mockResolvedValueOnce(Optional.of(resource))
+        .mockResolvedValueOnce(Optional.of(parentCircle))
+      resourceService.move.mockResolvedValue(buildResource({ parentId: 'new-parent' } as never))
+
+      const result = await controller.move(buildReq({ role: UserRoles.admin }), 'resource-1', 'new-parent')
+
+      expect(result.resource).toBeDefined()
+    })
+  })
+
+  describe('moveToOwnerCircle', () => {
+    it("devrait rejeter avec NotFoundResponse si la ressource n'existe pas", async () => {
+      resourceService.findByIdOrCode.mockResolvedValue(Optional.empty())
+
+      await expect(
+        controller.moveToOwnerCircle(buildReq({ role: UserRoles.admin }), 'unknown', 'owner-1')
+      ).rejects.toBeInstanceOf(NotFoundResponse)
+    })
+
+    it('devrait rejeter si la ressource est un cercle', async () => {
+      resourceService.findByIdOrCode.mockResolvedValue(Optional.of(buildResource({ type: ResourceTypes.CIRCLE })))
+
+      await expect(
+        controller.moveToOwnerCircle(buildReq({ role: UserRoles.admin }), 'resource-1', 'owner-1')
+      ).rejects.toBeInstanceOf(ForbiddenResponse)
+    })
+
+    it('devrait rejeter pour un non-admin', async () => {
+      resourceService.findByIdOrCode.mockResolvedValue(Optional.of(buildResource({ type: ResourceTypes.EXERCISE })))
+
+      await expect(
+        controller.moveToOwnerCircle(buildReq({ role: UserRoles.teacher }), 'resource-1', 'owner-1')
+      ).rejects.toBeInstanceOf(ForbiddenResponse)
+    })
+
+    it("devrait rejeter avec NotFoundResponse si le nouveau propriétaire n'existe pas", async () => {
+      resourceService.findByIdOrCode.mockResolvedValue(Optional.of(buildResource({ type: ResourceTypes.EXERCISE })))
+      userService.findById.mockResolvedValue(Optional.empty())
+
+      await expect(
+        controller.moveToOwnerCircle(buildReq({ role: UserRoles.admin }), 'resource-1', 'unknown-owner')
+      ).rejects.toBeInstanceOf(NotFoundResponse)
+    })
+
+    it('devrait déplacer la ressource vers le cercle personnel du nouveau propriétaire et notifier', async () => {
+      const existing = buildResource({ type: ResourceTypes.EXERCISE, parentId: 'old-parent' } as never)
+      resourceService.findByIdOrCode
+        .mockResolvedValueOnce(Optional.of(existing))
+        .mockResolvedValueOnce(Optional.of(buildResource({ id: 'old-parent' })))
+      userService.findById.mockResolvedValue(Optional.of(createUserEntity({ id: 'new-owner' }) as never))
+      resourceService.getPersonal.mockResolvedValue(buildResource({ id: 'new-owner-circle' }))
+      resourceService.move.mockResolvedValue(buildResource({ id: 'resource-1', parentId: 'new-owner-circle' } as never))
+
+      const result = await controller.moveToOwnerCircle(buildReq({ role: UserRoles.admin }), 'resource-1', 'new-owner')
+
+      expect(resourceService.move).toHaveBeenCalledWith('resource-1', 'new-owner-circle')
+      expect(notificationService.sendToUser).toHaveBeenCalledWith(
+        'new-owner',
+        expect.objectContaining({ type: 'RESOURCE-MOVED-BY-ADMIN' })
+      )
+      expect(result.resource).toBeDefined()
+    })
+  })
+
+  describe('delete', () => {
+    it("devrait rejeter avec NotFoundResponse si la ressource n'existe pas", async () => {
+      resourceService.findByIdOrCode.mockResolvedValue(Optional.empty())
+
+      await expect(controller.delete(buildReq(), 'unknown')).rejects.toBeInstanceOf(NotFoundResponse)
+    })
+
+    it("devrait rejeter avec ForbiddenResponse si le cercle parent n'est pas personnel", async () => {
+      const resource = buildResource({ parentId: 'parent-1' } as never)
+      resourceService.findByIdOrCode
+        .mockResolvedValueOnce(Optional.of(resource))
+        .mockResolvedValueOnce(Optional.of(buildResource({ id: 'parent-1', personal: false })))
+
+      await expect(controller.delete(buildReq(), 'resource-1')).rejects.toBeInstanceOf(ForbiddenResponse)
+    })
+
+    it('devrait supprimer le dépôt de fichiers puis la ressource', async () => {
+      const resource = buildResource({ parentId: 'parent-1' } as never)
+      resourceService.findByIdOrCode
+        .mockResolvedValueOnce(Optional.of(resource))
+        .mockResolvedValueOnce(Optional.of(buildResource({ id: 'parent-1', personal: true })))
+      const removeRepo = jest.fn().mockResolvedValue(undefined)
+      fileService.repo.mockResolvedValue({ repo: { removeRepo } } as never)
+
+      await controller.delete(buildReq(), 'resource-1')
+
+      expect(removeRepo).toHaveBeenCalled()
+      expect(resourceService.delete).toHaveBeenCalledWith(resource)
+    })
+  })
+
+  describe('isConfigurableExercise', () => {
+    it("devrait rejeter avec NotFoundResponse si la ressource n'existe pas", async () => {
+      resourceService.findByIdOrCode.mockResolvedValue(Optional.empty())
+
+      await expect(controller.isConfigurableExercise(buildReq(), 'unknown')).rejects.toBeInstanceOf(NotFoundResponse)
+    })
+
+    it("devrait rejeter avec ForbiddenResponse sans permission d'écriture", async () => {
+      resourceService.findByIdOrCode.mockResolvedValue(Optional.of(buildResource()))
+      permissionService.userPermissionsOnResource.mockResolvedValue(readOnlyPermissions)
+
+      await expect(controller.isConfigurableExercise(buildReq(), 'resource-1')).rejects.toBeInstanceOf(
+        ForbiddenResponse
+      )
+    })
+
+    it('devrait retourner le résultat du service', async () => {
+      resourceService.findByIdOrCode.mockResolvedValue(Optional.of(buildResource()))
+      resourceService.isConfigurableExercise.mockResolvedValue(true)
+
+      const result = await controller.isConfigurableExercise(buildReq(), 'resource-1')
+
+      expect(result.resource).toBe(true)
+    })
+  })
+
+  describe('updateTemplate', () => {
+    it("devrait rejeter avec NotFoundResponse si la ressource n'existe pas", async () => {
+      resourceService.findByIdOrCode.mockResolvedValue(Optional.empty())
+
+      await expect(controller.updateTemplate(buildReq(), 'unknown', 'template-1', 'v1')).rejects.toBeInstanceOf(
+        NotFoundResponse
+      )
+    })
+
+    it("devrait mettre à jour le template et créer le fichier PLO si la ressource ne l'était pas déjà", async () => {
+      const existing = buildResource({ templateId: undefined } as never)
+      resourceService.findByIdOrCode.mockResolvedValue(Optional.of(existing))
+      resourceService.update.mockResolvedValue(buildResource({ templateId: 'template-1' } as never))
+      const exists = jest.fn().mockResolvedValue(false)
+      const touch = jest.fn()
+      fileService.repo.mockResolvedValue({ repo: { exists, touch } } as never)
+
+      await controller.updateTemplate(buildReq(), 'resource-1', 'template-1', 'v1')
+
+      expect(dependencyService.updateTemplateDependency).toHaveBeenCalledWith(
+        expect.objectContaining({ resourceId: 'resource-1', dependOnId: 'template-1', isTemplate: true })
+      )
+      expect(touch).toHaveBeenCalled()
+    })
+
+    it('ne devrait pas retoucher le fichier PLO si la ressource était déjà un template', async () => {
+      const existing = buildResource({ templateId: 'old-template' } as never)
+      resourceService.findByIdOrCode.mockResolvedValue(Optional.of(existing))
+      resourceService.update.mockResolvedValue(buildResource({ templateId: 'template-1' } as never))
+
+      await controller.updateTemplate(buildReq(), 'resource-1', 'template-1', 'v1')
+
+      expect(fileService.repo).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('removeTemplate', () => {
+    it("devrait rejeter avec NotFoundResponse si la ressource n'existe pas", async () => {
+      resourceService.findByIdOrCode.mockResolvedValue(Optional.empty())
+
+      await expect(controller.removeTemplate(buildReq(), 'unknown')).rejects.toBeInstanceOf(NotFoundResponse)
+    })
+
+    it('devrait supprimer le template et sa dépendance', async () => {
+      resourceService.findByIdOrCode.mockResolvedValue(Optional.of(buildResource()))
+      resourceService.deleteTemplate = jest.fn().mockResolvedValue(buildResource())
+
+      await controller.removeTemplate(buildReq(), 'resource-1')
+
+      expect(dependencyService.deleteDependencyForVersion).toHaveBeenCalledWith('resource-1', expect.anything())
+    })
+  })
+
+  describe('updateCertification', () => {
+    it("devrait rejeter avec NotFoundResponse si la ressource n'existe pas", async () => {
+      resourceService.findByIdOrCode.mockResolvedValue(Optional.empty())
+
+      await expect(controller.updateCertification(buildReq(), 'unknown', true)).rejects.toBeInstanceOf(NotFoundResponse)
+    })
+
+    it("devrait rejeter si la ressource n'est pas un exercice", async () => {
+      resourceService.findByIdOrCode.mockResolvedValue(Optional.of(buildResource({ type: ResourceTypes.CIRCLE })))
+
+      await expect(controller.updateCertification(buildReq(), 'resource-1', true)).rejects.toBeInstanceOf(
+        BadRequestResponse
+      )
+    })
+
+    it('devrait rejeter pour un non-admin', async () => {
+      resourceService.findByIdOrCode.mockResolvedValue(Optional.of(buildResource({ type: ResourceTypes.EXERCISE })))
+
+      await expect(
+        controller.updateCertification(buildReq({ role: UserRoles.teacher }), 'resource-1', true)
+      ).rejects.toBeInstanceOf(ForbiddenResponse)
+    })
+
+    it('devrait mettre à jour la certification pour un admin', async () => {
+      resourceService.findByIdOrCode.mockResolvedValue(Optional.of(buildResource({ type: ResourceTypes.EXERCISE })))
+      resourceService.updateCertification.mockResolvedValue(buildResource({ type: ResourceTypes.EXERCISE }))
+
+      const result = await controller.updateCertification(buildReq({ role: UserRoles.admin }), 'resource-1', true)
+
+      expect(resourceService.updateCertification).toHaveBeenCalledWith('resource-1', true)
+      expect(result.resource).toBeDefined()
+    })
+  })
+})

--- a/libs/feature/resource/server/src/lib/resource.entity.ts
+++ b/libs/feature/resource/server/src/lib/resource.entity.ts
@@ -76,7 +76,7 @@ export class ResourceEntity extends BaseEntity {
   @JoinColumn({ name: 'parent_id' })
   parent?: ResourceEntity
 
-  @Index('Resources_parent_idx')
+  @Index('Resources_template_idx')
   @Column({ name: 'template_id', nullable: true })
   templateId?: string
 

--- a/libs/feature/resource/server/src/lib/resource.service.integration.spec.ts
+++ b/libs/feature/resource/server/src/lib/resource.service.integration.spec.ts
@@ -1,0 +1,280 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { LevelEntity, TopicEntity, UserEntity } from '@platon/core/server'
+import { UserRoles } from '@platon/core/common'
+import { createTestDatabase, TestDatabase } from '@platon/core/testing/server'
+import { ResourceOrderings, ResourceStatus, ResourceTypes } from '@platon/feature/resource/common'
+import { DataSource, Repository } from 'typeorm'
+import { ResourceMemberEntity } from './members/member.entity'
+import { ResourceMetaEntity } from './metadata/metadata.entity'
+import { ResourceEntity } from './resource.entity'
+import { ResourceService } from './resource.service'
+import { ResourceWatcherEntity } from './watchers/watcher.entity'
+
+// Réplique la migration 1676148287928-EnableUnaccentSearch : createTestDatabase() ne fait que
+// `synchronize: true` (schéma depuis les entités), ce qui ne joue jamais les migrations — donc
+// f_unaccent() (utilisée par ResourceService.search()) n'existe pas dans la base de test sans ça.
+const UNACCENT_SETUP_SQL = [
+  `CREATE EXTENSION IF NOT EXISTS unaccent`,
+  `
+    CREATE OR REPLACE FUNCTION public.f_unaccent(text)
+    RETURNS text
+    LANGUAGE sql IMMUTABLE PARALLEL SAFE STRICT AS
+    $func$
+    SELECT public.unaccent('public.unaccent', $1)
+    $func$;
+  `,
+]
+
+describe('ResourceService (integration)', () => {
+  let testDb: TestDatabase
+  let dataSource: DataSource
+  let userRepo: Repository<UserEntity>
+  let resourceRepo: Repository<ResourceEntity>
+  let memberRepo: Repository<ResourceMemberEntity>
+  let watcherRepo: Repository<ResourceWatcherEntity>
+  let service: ResourceService
+
+  const mockDeps = {
+    levelService: { findById: jest.fn(), findAll: jest.fn() },
+    topicService: { findById: jest.fn(), findAll: jest.fn() },
+    eventService: { emit: jest.fn() },
+  }
+
+  beforeAll(async () => {
+    testDb = await createTestDatabase(
+      [
+        UserEntity,
+        LevelEntity,
+        TopicEntity,
+        ResourceEntity,
+        ResourceMemberEntity,
+        ResourceWatcherEntity,
+        ResourceMetaEntity,
+      ],
+      UNACCENT_SETUP_SQL
+    )
+    dataSource = testDb.dataSource
+    userRepo = dataSource.getRepository(UserEntity)
+    resourceRepo = dataSource.getRepository(ResourceEntity)
+    memberRepo = dataSource.getRepository(ResourceMemberEntity)
+    watcherRepo = dataSource.getRepository(ResourceWatcherEntity)
+
+    service = new ResourceService(
+      resourceRepo,
+      dataSource.getRepository(ResourceMetaEntity),
+      dataSource,
+      mockDeps.levelService as any,
+      mockDeps.topicService as any,
+      mockDeps.eventService as any
+    )
+  }, 60_000)
+
+  afterAll(async () => {
+    await testDb.teardown()
+  })
+
+  afterEach(async () => {
+    await dataSource.query('TRUNCATE "ResourceMembers" CASCADE')
+    await dataSource.query('TRUNCATE "ResourceWatchers" CASCADE')
+    await dataSource.query('TRUNCATE "Resources" CASCADE')
+    await dataSource.query('TRUNCATE "Users" CASCADE')
+  })
+
+  let userCounter = 0
+  const seedUser = async (overrides: Partial<UserEntity> = {}): Promise<UserEntity> => {
+    userCounter++
+    return userRepo.save(
+      userRepo.create({
+        username: `integration-user-${userCounter}`,
+        firstName: 'Test',
+        lastName: 'User',
+        email: `integration-user-${userCounter}@test.local`,
+        role: UserRoles.teacher,
+        active: true,
+        lastActivity: new Date(),
+        ...overrides,
+      })
+    )
+  }
+
+  const seedResource = async (overrides: Partial<ResourceEntity> = {}): Promise<ResourceEntity> => {
+    return resourceRepo.save(
+      resourceRepo.create({
+        name: 'Resource',
+        type: ResourceTypes.CIRCLE,
+        status: ResourceStatus.READY,
+        personal: false,
+        ...overrides,
+      })
+    )
+  }
+
+  describe('search — recherche insensible aux accents (f_unaccent)', () => {
+    it('devrait trouver les ressources avec ou sans accent sur le terme recherché', async () => {
+      const owner = await seedUser()
+      await seedResource({ name: 'Éléphant rose', ownerId: owner.id })
+      await seedResource({ name: 'Elephant bleu', ownerId: owner.id })
+      await seedResource({ name: 'Girafe verte', ownerId: owner.id })
+
+      const [results] = await service.search({ search: 'elephant', order: ResourceOrderings.NAME })
+
+      expect(results.map((r) => r.name).sort()).toEqual(['Elephant bleu', 'Éléphant rose'])
+    })
+
+    it('devrait aussi matcher si le terme de recherche est lui-même accentué', async () => {
+      const owner = await seedUser()
+      await seedResource({ name: 'Elephant bleu', ownerId: owner.id })
+
+      const [results] = await service.search({ search: 'éléphant', order: ResourceOrderings.NAME })
+
+      expect(results).toHaveLength(1)
+    })
+  })
+
+  describe('search — permissions (requête SQL brute members/watchers)', () => {
+    it("devrait toujours exposer les ressources non personnelles, même sans lien avec l'utilisateur", async () => {
+      const owner = await seedUser()
+      const stranger = await seedUser()
+      await seedResource({ name: 'Public circle', ownerId: owner.id, personal: false })
+
+      const [results] = await service.search({ order: ResourceOrderings.NAME }, stranger.id)
+
+      expect(results.map((r) => r.name)).toContain('Public circle')
+    })
+
+    it('ne devrait pas exposer une ressource personnelle à un utilisateur sans lien avec elle', async () => {
+      const owner = await seedUser()
+      const stranger = await seedUser()
+      await seedResource({ name: 'Private circle', ownerId: owner.id, personal: true })
+
+      const [results] = await service.search({ order: ResourceOrderings.NAME }, stranger.id)
+
+      expect(results.map((r) => r.name)).not.toContain('Private circle')
+    })
+
+    it('devrait exposer une ressource personnelle à un membre avec droit de lecture', async () => {
+      const owner = await seedUser()
+      const member = await seedUser()
+      const resource = await seedResource({ name: 'Private circle', ownerId: owner.id, personal: true })
+      await memberRepo.save(
+        memberRepo.create({
+          resourceId: resource.id,
+          userId: member.id,
+          inviterId: owner.id,
+          permissions: { read: true, write: false },
+        })
+      )
+
+      const [results] = await service.search({ order: ResourceOrderings.NAME }, member.id)
+
+      expect(results.map((r) => r.name)).toContain('Private circle')
+    })
+
+    it('devrait exposer une ressource personnelle à un observateur (watcher)', async () => {
+      const owner = await seedUser()
+      const watcher = await seedUser()
+      const resource = await seedResource({ name: 'Private circle', ownerId: owner.id, personal: true })
+      await watcherRepo.save(watcherRepo.create({ resourceId: resource.id, userId: watcher.id }))
+
+      const [results] = await service.search({ order: ResourceOrderings.NAME }, watcher.id)
+
+      expect(results.map((r) => r.name)).toContain('Private circle')
+    })
+
+    it('devrait toujours exposer une ressource personnelle à son propriétaire', async () => {
+      const owner = await seedUser()
+      await seedResource({ name: 'Private circle', ownerId: owner.id, personal: true })
+
+      const [results] = await service.search({ order: ResourceOrderings.NAME }, owner.id)
+
+      expect(results.map((r) => r.name)).toContain('Private circle')
+    })
+  })
+
+  describe('create', () => {
+    it('devrait créer une ressource et hériter du caractère personnel du parent', async () => {
+      const owner = await seedUser()
+      const parent = await seedResource({ name: 'Parent', ownerId: owner.id, personal: true })
+
+      const created = await service.create({
+        name: 'Child',
+        parentId: parent.id,
+        type: ResourceTypes.CIRCLE,
+        ownerId: owner.id,
+      })
+
+      expect(created.personal).toBe(true)
+      const reloaded = await resourceRepo.findOneOrFail({ where: { id: created.id } })
+      expect(reloaded.parentId).toBe(parent.id)
+    })
+
+    it("devrait rejeter si le parent référencé n'existe pas (contrainte réelle)", async () => {
+      await expect(
+        service.create({ name: 'Orphan', parentId: '00000000-0000-0000-0000-000000000000', type: ResourceTypes.CIRCLE })
+      ).rejects.toThrow()
+    })
+  })
+
+  describe('move', () => {
+    it('devrait déplacer une ressource et hériter du caractère personnel du nouveau parent', async () => {
+      const owner = await seedUser()
+      const oldParent = await seedResource({ name: 'Old parent', ownerId: owner.id, personal: false })
+      const newParent = await seedResource({ name: 'New parent', ownerId: owner.id, personal: true })
+      const resource = await seedResource({
+        name: 'Movable',
+        ownerId: owner.id,
+        personal: false,
+        parentId: oldParent.id,
+      } as never)
+
+      await service.move(resource.id, newParent.id)
+
+      const reloaded = await resourceRepo.findOneOrFail({ where: { id: resource.id } })
+      expect(reloaded.parentId).toBe(newParent.id)
+      expect(reloaded.personal).toBe(true)
+    })
+  })
+
+  describe('hiérarchie de cercles (tree / getDescendants / getParents)', () => {
+    it('devrait retourner tous les descendants dans le bon ordre hiérarchique', async () => {
+      const owner = await seedUser()
+      const root = await seedResource({ name: 'Root', ownerId: owner.id })
+      const child = await seedResource({ name: 'Child', ownerId: owner.id, parentId: root.id } as never)
+      const grandchild = await seedResource({
+        name: 'Grandchild',
+        ownerId: owner.id,
+        parentId: child.id,
+      } as never)
+
+      const descendants = await service.getDescendants(root.id)
+
+      expect(descendants.map((r) => r.id)).toEqual([child.id, grandchild.id])
+    })
+
+    it('devrait retourner tous les parents dans le bon ordre hiérarchique', async () => {
+      const owner = await seedUser()
+      const root = await seedResource({ name: 'Root', ownerId: owner.id })
+      const child = await seedResource({ name: 'Child', ownerId: owner.id, parentId: root.id } as never)
+      const grandchild = await seedResource({
+        name: 'Grandchild',
+        ownerId: owner.id,
+        parentId: child.id,
+      } as never)
+
+      const parents = await service.getParents(grandchild.id)
+
+      expect(parents.map((r) => r.id)).toEqual([child.id, root.id])
+    })
+
+    it("devrait construire l'arbre des cercles avec les métadonnées de version", async () => {
+      const owner = await seedUser()
+      const root = await seedResource({ name: 'Root', ownerId: owner.id })
+      const child = await seedResource({ name: 'Child', ownerId: owner.id, parentId: root.id } as never)
+
+      const tree = await service.tree([root, child])
+
+      expect(tree.id).toBe(root.id)
+      expect(tree.children?.[0].id).toBe(child.id)
+    })
+  })
+})

--- a/libs/feature/resource/server/src/lib/resource.service.spec.ts
+++ b/libs/feature/resource/server/src/lib/resource.service.spec.ts
@@ -1,0 +1,527 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { getRepositoryToken } from '@nestjs/typeorm'
+import { NotFoundResponse } from '@platon/core/common'
+import { EventService, LevelService, TopicService } from '@platon/core/server'
+import { MockRepository, mockRepository, mockSelectQueryBuilder, createUserEntity } from '@platon/core/testing/server'
+import { ResourceOrderings, ResourceStatus, ResourceTypes } from '@platon/feature/resource/common'
+import { Optional } from 'typescript-optional'
+import { DataSource } from 'typeorm'
+import { ResourceEntity } from './resource.entity'
+import { ResourceMetaEntity } from './metadata/metadata.entity'
+import { ResourceService } from './resource.service'
+import { ON_CREATE_RESOURCE_EVENT } from './resource.event'
+
+describe('ResourceService', () => {
+  let service: ResourceService
+  let repository: MockRepository<ResourceEntity>
+  let metadataRepo: MockRepository<ResourceMetaEntity>
+  let dataSource: { query: jest.Mock; getRepository: jest.Mock }
+  let levelService: jest.Mocked<LevelService>
+  let topicService: jest.Mocked<TopicService>
+  let eventService: jest.Mocked<EventService>
+
+  beforeEach(async () => {
+    dataSource = { query: jest.fn(), getRepository: jest.fn() }
+
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ResourceService,
+        { provide: getRepositoryToken(ResourceEntity), useValue: mockRepository<ResourceEntity>() },
+        { provide: getRepositoryToken(ResourceMetaEntity), useValue: mockRepository<ResourceMetaEntity>() },
+        { provide: DataSource, useValue: dataSource },
+        { provide: LevelService, useValue: { findById: jest.fn(), findAll: jest.fn() } },
+        { provide: TopicService, useValue: { findById: jest.fn(), findAll: jest.fn() } },
+        { provide: EventService, useValue: { emit: jest.fn() } },
+      ],
+    }).compile()
+
+    service = module.get(ResourceService)
+    repository = module.get(getRepositoryToken(ResourceEntity))
+    metadataRepo = module.get(getRepositoryToken(ResourceMetaEntity))
+    levelService = module.get(LevelService)
+    topicService = module.get(TopicService)
+    eventService = module.get(EventService)
+  })
+
+  const buildResource = (overrides: Partial<ResourceEntity> = {}): ResourceEntity =>
+    ({
+      id: 'resource-1',
+      name: 'Resource 1',
+      type: ResourceTypes.CIRCLE,
+      status: ResourceStatus.READY,
+      personal: false,
+      ...overrides,
+    } as ResourceEntity)
+
+  describe('tree', () => {
+    it('devrait construire un arbre à partir des cercles et de leurs métadonnées de version', async () => {
+      const root = buildResource({ id: 'root' })
+      metadataRepo.find.mockResolvedValue([
+        { resourceId: 'root', meta: { versions: [{ tag: 'v1' }, { tag: 'v2' }] } } as unknown as ResourceMetaEntity,
+      ])
+
+      const result = await service.tree([root])
+
+      expect(result.id).toBe('root')
+    })
+
+    it('ne devrait pas requêter les métadonnées si la liste de cercles est vide', async () => {
+      await expect(service.tree([])).rejects.toThrow('Root circle not found')
+
+      expect(metadataRepo.find).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('getById', () => {
+    it('devrait charger topics/levels par défaut', async () => {
+      const qb = mockSelectQueryBuilder<ResourceEntity>()
+      const resource = buildResource()
+      qb.getOneOrFail.mockResolvedValue(resource)
+      repository.createQueryBuilder.mockReturnValue(qb)
+
+      const result = await service.getById('resource-1')
+
+      expect(qb.leftJoinAndSelect).toHaveBeenCalledWith('resource.topics', 'topic')
+      expect(qb.leftJoinAndSelect).toHaveBeenCalledWith('resource.levels', 'level')
+      expect(result).toBe(resource)
+    })
+
+    it('ne devrait pas charger topics/levels si resolveTags=false', async () => {
+      const qb = mockSelectQueryBuilder<ResourceEntity>()
+      qb.getOneOrFail.mockResolvedValue(buildResource())
+      repository.createQueryBuilder.mockReturnValue(qb)
+
+      await service.getById('resource-1', false)
+
+      expect(qb.leftJoinAndSelect).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('findByIdOrCode', () => {
+    it('devrait chercher par id si la valeur est un UUID valide', async () => {
+      const qb = mockSelectQueryBuilder<ResourceEntity>()
+      const resource = buildResource()
+      qb.getOne.mockResolvedValue(resource)
+      repository.createQueryBuilder.mockReturnValue(qb)
+
+      const result = await service.findByIdOrCode('123e4567-e89b-42d3-a456-556642440001')
+
+      expect(qb.where).toHaveBeenCalledWith('resource.id = :id', { id: '123e4567-e89b-42d3-a456-556642440001' })
+      expect(result.get()).toBe(resource)
+    })
+
+    it("devrait chercher par code si la valeur n'est pas un UUID", async () => {
+      const qb = mockSelectQueryBuilder<ResourceEntity>()
+      qb.getOne.mockResolvedValue(null)
+      repository.createQueryBuilder.mockReturnValue(qb)
+
+      const result = await service.findByIdOrCode('my-code')
+
+      expect(qb.where).toHaveBeenCalledWith('resource.code = :code', { code: 'my-code' })
+      expect(result.isPresent()).toBe(false)
+    })
+  })
+
+  describe('getPersonal', () => {
+    it('devrait retourner le cercle personnel existant sans le recréer', async () => {
+      const circle = buildResource({ personal: true })
+      repository.findOne.mockResolvedValue(circle)
+      const owner = createUserEntity()
+
+      const result = await service.getPersonal(owner as never)
+
+      expect(repository.save).not.toHaveBeenCalled()
+      expect(result).toBe(circle)
+    })
+
+    it("devrait créer le cercle personnel s'il n'existe pas encore", async () => {
+      repository.findOne.mockResolvedValue(null)
+      const owner = createUserEntity({ id: 'owner-1', username: 'testuser' })
+      const created = buildResource({ ownerId: 'owner-1', personal: true } as never)
+      repository.create.mockReturnValue(created)
+      repository.save.mockResolvedValue(created)
+
+      const result = await service.getPersonal(owner as never)
+
+      expect(repository.create).toHaveBeenCalledWith(
+        expect.objectContaining({ ownerId: 'owner-1', type: ResourceTypes.CIRCLE, personal: true })
+      )
+      expect(result).toBe(created)
+    })
+  })
+
+  describe('getDescendants', () => {
+    it('devrait retourner un tableau vide si le cercle racine est introuvable', async () => {
+      repository.find.mockResolvedValue([])
+
+      const result = await service.getDescendants('unknown')
+
+      expect(result).toEqual([])
+    })
+
+    it('devrait retourner tous les descendants récursivement', async () => {
+      const root = buildResource({ id: 'root' })
+      const child1 = buildResource({ id: 'child1', parentId: 'root' } as never)
+      const child2 = buildResource({ id: 'child2', parentId: 'child1' } as never)
+      const unrelated = buildResource({ id: 'unrelated' })
+      repository.find.mockResolvedValue([root, child1, child2, unrelated])
+
+      const result = await service.getDescendants('root')
+
+      expect(result.map((r) => r.id)).toEqual(['child1', 'child2'])
+    })
+  })
+
+  describe('getParents', () => {
+    it('devrait retourner un tableau vide si le cercle racine est introuvable', async () => {
+      repository.find.mockResolvedValue([])
+
+      const result = await service.getParents('unknown')
+
+      expect(result).toEqual([])
+    })
+
+    it('devrait retourner tous les parents récursivement', async () => {
+      const grandparent = buildResource({ id: 'grandparent' })
+      const parent = buildResource({ id: 'parent', parentId: 'grandparent' } as never)
+      const child = buildResource({ id: 'child', parentId: 'parent' } as never)
+      repository.find.mockResolvedValue([grandparent, parent, child])
+
+      const result = await service.getParents('child')
+
+      expect(result.map((r) => r.id)).toEqual(['parent', 'grandparent'])
+    })
+  })
+
+  describe('search', () => {
+    it("devrait vérifier les permissions de l'utilisateur si userId est fourni", async () => {
+      const qb = mockSelectQueryBuilder<ResourceEntity>()
+      repository.createQueryBuilder.mockReturnValue(qb)
+      dataSource.query.mockResolvedValue([{ resource_id: 'res-1' }])
+
+      await service.search({}, 'user-1')
+
+      expect(dataSource.query).toHaveBeenCalledWith(expect.stringContaining('ResourceMembers'), ['user-1'])
+      expect(qb.andWhere).toHaveBeenCalledWith(expect.anything())
+    })
+
+    it("ne devrait pas vérifier les permissions si userId n'est pas fourni", async () => {
+      const qb = mockSelectQueryBuilder<ResourceEntity>()
+      repository.createQueryBuilder.mockReturnValue(qb)
+
+      await service.search({})
+
+      expect(dataSource.query).not.toHaveBeenCalled()
+    })
+
+    it('devrait joindre les statistiques quand le tri est RELEVANCE (par défaut)', async () => {
+      const qb = mockSelectQueryBuilder<ResourceEntity>()
+      repository.createQueryBuilder.mockReturnValue(qb)
+
+      await service.search({})
+
+      expect(qb.leftJoinAndSelect).toHaveBeenCalledWith(expect.anything(), 'stats', 'stats.id = resource.id')
+      expect(qb.orderBy).toHaveBeenCalledWith('stats.score', 'DESC')
+    })
+
+    it('devrait filtrer par membres via un innerJoin', async () => {
+      const qb = mockSelectQueryBuilder<ResourceEntity>()
+      repository.createQueryBuilder.mockReturnValue(qb)
+
+      await service.search({ members: ['user-1'] })
+
+      expect(qb.innerJoin).toHaveBeenCalledWith(
+        expect.anything(),
+        'member',
+        'member.resource_id = resource.id AND member.user_id IN (:...ids)',
+        { ids: ['user-1'] }
+      )
+    })
+
+    it('devrait filtrer par types et statuts', async () => {
+      const qb = mockSelectQueryBuilder<ResourceEntity>()
+      repository.createQueryBuilder.mockReturnValue(qb)
+
+      await service.search({ types: [ResourceTypes.EXERCISE], status: [ResourceStatus.READY] })
+
+      expect(qb.andWhere).toHaveBeenCalledWith('type IN (:...types)', { types: [ResourceTypes.EXERCISE] })
+      expect(qb.andWhere).toHaveBeenCalledWith('status IN (:...status)', { status: [ResourceStatus.READY] })
+    })
+
+    it('devrait filtrer par texte de recherche avec f_unaccent', async () => {
+      const qb = mockSelectQueryBuilder<ResourceEntity>()
+      repository.createQueryBuilder.mockReturnValue(qb)
+
+      await service.search({ search: '  intro  ' })
+
+      expect(qb.andWhere).toHaveBeenCalledWith(expect.stringContaining('f_unaccent'), { search: '%intro%' })
+    })
+
+    it('devrait trier par nom quand demandé explicitement', async () => {
+      const qb = mockSelectQueryBuilder<ResourceEntity>()
+      repository.createQueryBuilder.mockReturnValue(qb)
+
+      await service.search({ order: ResourceOrderings.NAME })
+
+      expect(qb.orderBy).toHaveBeenCalledWith('resource.name', 'ASC')
+    })
+
+    it('devrait appliquer offset (skip) et limit (take)', async () => {
+      const qb = mockSelectQueryBuilder<ResourceEntity>()
+      repository.createQueryBuilder.mockReturnValue(qb)
+
+      await service.search({ offset: 5, limit: 10 })
+
+      expect(qb.skip).toHaveBeenCalledWith(5)
+      expect(qb.take).toHaveBeenCalledWith(10)
+    })
+
+    it('devrait retourner le résultat de getManyAndCount', async () => {
+      const qb = mockSelectQueryBuilder<ResourceEntity>()
+      const resources = [buildResource()]
+      qb.getManyAndCount.mockResolvedValue([resources, 1])
+      repository.createQueryBuilder.mockReturnValue(qb)
+
+      const result = await service.search({})
+
+      expect(result).toEqual([resources, 1])
+    })
+  })
+
+  describe('create', () => {
+    it('devrait hériter du caractère personnel du parent et émettre un événement de création', async () => {
+      const parent = buildResource({ id: 'parent-1', personal: true })
+      repository.findOneOrFail.mockResolvedValue(parent)
+      const created = buildResource({ id: 'new-resource', personal: true })
+      repository.create.mockReturnValue(created)
+      repository.save.mockResolvedValue(created)
+
+      const result = await service.create({ parentId: 'parent-1', name: 'New' })
+
+      expect(repository.create).toHaveBeenCalledWith(expect.objectContaining({ personal: true }))
+      expect(eventService.emit).toHaveBeenCalledWith(ON_CREATE_RESOURCE_EVENT, { resource: created })
+      expect(result).toBe(created)
+    })
+  })
+
+  describe('delete', () => {
+    it('devrait supprimer la ressource', async () => {
+      const resource = buildResource()
+
+      await service.delete(resource)
+
+      expect(repository.remove).toHaveBeenCalledWith(resource)
+    })
+  })
+
+  describe('update', () => {
+    it("devrait rejeter avec NotFoundResponse si l'id ne correspond à aucune ressource", async () => {
+      repository.findOne.mockResolvedValue(null)
+
+      await expect(service.update('unknown', { name: 'New' })).rejects.toBeInstanceOf(NotFoundResponse)
+    })
+
+    it('devrait fusionner les changements et sauvegarder quand un id est fourni', async () => {
+      const resource = buildResource({ name: 'Old' })
+      repository.findOne.mockResolvedValue(resource)
+      repository.save.mockImplementation(async (r) => r as ResourceEntity)
+
+      const result = await service.update('resource-1', { name: 'New' })
+
+      expect(result.name).toBe('New')
+    })
+
+    it('devrait accepter directement une entité sans requête supplémentaire', async () => {
+      const resource = buildResource({ name: 'Old' })
+      repository.save.mockImplementation(async (r) => r as ResourceEntity)
+
+      await service.update(resource, { name: 'New' })
+
+      expect(repository.findOne).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('deleteTemplate', () => {
+    it('devrait retirer les informations de template', async () => {
+      const resource = buildResource({ templateId: 'template-1' } as never)
+      repository.findOneOrFail.mockResolvedValue(resource)
+      repository.save.mockImplementation(async (r) => r as ResourceEntity)
+
+      const result = await service.deleteTemplate('resource-1')
+
+      expect(result.templateId).toBeNull()
+      expect((result as never as { template: unknown }).template).toBeNull()
+    })
+  })
+
+  describe('move', () => {
+    it('devrait déplacer une ressource simple sous le nouveau parent', async () => {
+      const resource = buildResource({ id: 'res-1', type: ResourceTypes.CIRCLE })
+      const parent = buildResource({ id: 'parent-1', personal: true })
+      repository.findOneOrFail.mockResolvedValueOnce(resource).mockResolvedValueOnce(parent)
+      repository.save.mockImplementation(async (r) => r as ResourceEntity)
+
+      const result = await service.move('res-1', 'parent-1')
+
+      expect(result.parentId).toBe('parent-1')
+      expect(result.personal).toBe(true)
+    })
+
+    it('devrait déplacer en cascade les exercices utilisés par une activité déplacée', async () => {
+      const activity = buildResource({ id: 'activity-1', type: ResourceTypes.ACTIVITY })
+      const parent = buildResource({ id: 'parent-1', personal: false })
+      const exercise = buildResource({ id: 'exercise-1', type: ResourceTypes.EXERCISE })
+
+      repository.findOneOrFail
+        .mockResolvedValueOnce(activity)
+        .mockResolvedValueOnce(parent)
+        .mockResolvedValueOnce(exercise)
+        .mockResolvedValueOnce(parent)
+      repository.save.mockImplementation(async (r) => r as ResourceEntity)
+      const qb = mockSelectQueryBuilder<ResourceEntity>()
+      qb.getManyAndCount.mockResolvedValue([[exercise], 1])
+      repository.createQueryBuilder.mockReturnValue(qb)
+
+      await service.move('activity-1', 'parent-1')
+
+      expect(repository.findOneOrFail).toHaveBeenCalledTimes(4)
+    })
+  })
+
+  describe('completion', () => {
+    it('devrait agréger les niveaux, topics et noms de ressources', async () => {
+      levelService.findAll.mockResolvedValue([[{ name: 'Level 1' }] as never, 1])
+      topicService.findAll.mockResolvedValue([[{ name: 'Topic 1' }] as never, 1])
+      repository.find.mockResolvedValue([{ name: 'Resource 1' } as ResourceEntity])
+      const user = createUserEntity()
+
+      const result = await service.completion(user as never)
+
+      expect(result).toEqual({ levels: ['Level 1'], topics: ['Topic 1'], names: ['Resource 1'] })
+    })
+  })
+
+  describe('fromInput', () => {
+    it('ne devrait pas toucher levels/topics si non fournis', async () => {
+      const result = await service.fromInput({ name: 'New', parentId: 'parent-1', type: ResourceTypes.CIRCLE })
+
+      expect(result.levels).toBeUndefined()
+      expect(result.topics).toBeUndefined()
+    })
+
+    it('devrait résoudre les niveaux fournis et rejeter si un niveau est introuvable', async () => {
+      levelService.findById.mockResolvedValue(Optional.empty())
+
+      await expect(service.fromInput({ levels: ['unknown'] } as never)).rejects.toBeInstanceOf(NotFoundResponse)
+    })
+
+    it('devrait résoudre les topics fournis et rejeter si un topic est introuvable', async () => {
+      topicService.findById.mockResolvedValue(Optional.empty())
+
+      await expect(service.fromInput({ topics: ['unknown'] } as never)).rejects.toBeInstanceOf(NotFoundResponse)
+    })
+  })
+
+  describe('notificationWatchers', () => {
+    it('devrait retourner les ids uniques des membres, watchers et du propriétaire, sans valeur nulle', async () => {
+      dataSource.query.mockResolvedValue([{ user_id: 'user-1' }, { user_id: null }, { user_id: 'user-2' }])
+
+      const result = await service.notificationWatchers('resource-1')
+
+      expect(result).toEqual(['user-1', 'user-2'])
+    })
+  })
+
+  describe('isConfigurableExercise', () => {
+    it("devrait retourner false si la ressource n'existe pas", async () => {
+      repository.findOne.mockResolvedValue(null)
+
+      const result = await service.isConfigurableExercise('unknown')
+
+      expect(result).toBe(false)
+    })
+
+    it("devrait retourner false si la ressource n'est pas un exercice", async () => {
+      repository.findOne.mockResolvedValue(buildResource({ type: ResourceTypes.CIRCLE }))
+
+      const result = await service.isConfigurableExercise('resource-1')
+
+      expect(result).toBe(false)
+    })
+
+    it('devrait retourner la valeur configurable des métadonnées pour un exercice', async () => {
+      repository.findOne.mockResolvedValue(buildResource({ type: ResourceTypes.EXERCISE }))
+      metadataRepo.findOne.mockResolvedValue({ meta: { configurable: true } } as unknown as ResourceMetaEntity)
+
+      const result = await service.isConfigurableExercise('resource-1')
+
+      expect(result).toBe(true)
+    })
+  })
+
+  describe('handleDeleteOrphanCircles', () => {
+    it('devrait supprimer tous les cercles personnels orphelins', async () => {
+      const orphan1 = buildResource({ id: 'orphan-1' })
+      const orphan2 = buildResource({ id: 'orphan-2' })
+      repository.find.mockResolvedValue([orphan1, orphan2])
+
+      await service.handleDeleteOrphanCircles()
+      await new Promise((resolve) => setTimeout(resolve, 0))
+
+      expect(repository.remove).toHaveBeenCalledWith(orphan1)
+      expect(repository.remove).toHaveBeenCalledWith(orphan2)
+    })
+  })
+
+  describe('onTopicFusion / onLevelFusion', () => {
+    it("devrait remplacer l'ancien topic par le nouveau dans chaque ressource concernée", async () => {
+      const oldTopic = { id: 'old-topic' } as never
+      const newTopic = { id: 'new-topic' } as never
+      const resource = buildResource({ topics: [oldTopic] } as never)
+      const qb = mockSelectQueryBuilder<ResourceEntity>()
+      qb.getMany.mockResolvedValue([resource])
+      repository.createQueryBuilder.mockReturnValue(qb)
+      repository.save.mockImplementation(async (r) => r as ResourceEntity)
+
+      await service.onTopicFusion({ oldTopic, newTopic })
+
+      expect(resource.topics).toEqual([newTopic])
+    })
+
+    it("devrait remplacer l'ancien niveau par le nouveau dans chaque ressource concernée", async () => {
+      const oldLevel = { id: 'old-level' } as never
+      const newLevel = { id: 'new-level' } as never
+      const resource = buildResource({ levels: [oldLevel] } as never)
+      const qb = mockSelectQueryBuilder<ResourceEntity>()
+      qb.getMany.mockResolvedValue([resource])
+      repository.createQueryBuilder.mockReturnValue(qb)
+      repository.save.mockImplementation(async (r) => r as ResourceEntity)
+
+      await service.onLevelFusion({ oldLevel, newLevel })
+
+      expect(resource.levels).toEqual([newLevel])
+    })
+  })
+
+  describe('updateCertification', () => {
+    it("devrait rejeter avec NotFoundResponse si la ressource n'existe pas ou n'est pas un exercice", async () => {
+      repository.findOne.mockResolvedValue(null)
+
+      await expect(service.updateCertification('unknown', true)).rejects.toBeInstanceOf(NotFoundResponse)
+    })
+
+    it('devrait créer les métadonnées si absentes puis définir certifiedTemplate', async () => {
+      const resource = buildResource({ type: ResourceTypes.EXERCISE })
+      repository.findOne.mockResolvedValue(resource)
+      metadataRepo.findOne.mockResolvedValue(null)
+      const created = { resourceId: 'resource-1', meta: {} } as unknown as ResourceMetaEntity
+      metadataRepo.create.mockReturnValue(created)
+      metadataRepo.save.mockImplementation(async (m) => m as ResourceMetaEntity)
+      repository.save.mockImplementation(async (r) => r as ResourceEntity)
+
+      await service.updateCertification('resource-1', true)
+
+      expect((created.meta as { certifiedTemplate: boolean }).certifiedTemplate).toBe(true)
+    })
+  })
+})

--- a/libs/feature/resource/server/src/lib/resource.subscriber.spec.ts
+++ b/libs/feature/resource/server/src/lib/resource.subscriber.spec.ts
@@ -75,8 +75,7 @@ describe('ResourceSubscriber', () => {
       expect(manager.save).not.toHaveBeenCalled()
     })
 
-    it('devrait créer un événement de changement de statut', async () => {
-      resourceService.getById.mockResolvedValue({ name: 'Parent circle' } as never)
+    it("devrait créer un événement de changement de statut sans appeler getById si la ressource n'a pas de parent", async () => {
       const manager = buildManager()
       const event = {
         entity: { id: 'res-1', type: 'EXERCISE', name: 'Exo', status: 'READY', parentId: undefined },
@@ -86,6 +85,9 @@ describe('ResourceSubscriber', () => {
 
       await subscriber.afterUpdate(event as never)
 
+      // Régression : getById(undefined) fait un WHERE id = NULL en base réelle, qui échoue
+      // toujours avec EntityNotFoundError (getOneOrFail) — donc ne doit jamais être appelé ici.
+      expect(resourceService.getById).not.toHaveBeenCalled()
       expect(manager.save).toHaveBeenCalledTimes(1)
       expect(manager.create).toHaveBeenCalledWith(
         expect.anything(),

--- a/libs/feature/resource/server/src/lib/resource.subscriber.spec.ts
+++ b/libs/feature/resource/server/src/lib/resource.subscriber.spec.ts
@@ -1,0 +1,117 @@
+import { IRequest } from '@platon/core/server'
+import { ResourceEventTypes } from '@platon/feature/resource/common'
+import { DataSource } from 'typeorm'
+import { ResourceService } from './resource.service'
+import { ResourceSubscriber } from './resource.subscriber'
+
+describe('ResourceSubscriber', () => {
+  let subscriber: ResourceSubscriber
+  let resourceService: jest.Mocked<ResourceService>
+  let dataSource: { subscribers: unknown[] }
+  let request: IRequest
+
+  const buildManager = () => ({
+    save: jest.fn().mockResolvedValue(undefined),
+    create: jest.fn((_entity: unknown, data: unknown) => data),
+  })
+
+  beforeEach(() => {
+    resourceService = { getById: jest.fn() } as unknown as jest.Mocked<ResourceService>
+    dataSource = { subscribers: [] }
+    request = { user: { id: 'user-1' } } as unknown as IRequest
+    subscriber = new ResourceSubscriber(resourceService, dataSource as unknown as DataSource, request)
+  })
+
+  it("devrait s'enregistrer auprès du DataSource", () => {
+    expect(dataSource.subscribers).toContain(subscriber)
+  })
+
+  describe('afterInsert', () => {
+    it('devrait toujours créer un watcher pour le propriétaire', async () => {
+      const manager = buildManager()
+      const event = { entity: { id: 'res-1', ownerId: 'owner-1' }, manager }
+
+      await subscriber.afterInsert(event as never)
+
+      expect(manager.create).toHaveBeenCalledWith(expect.anything(), { resourceId: 'res-1', userId: 'owner-1' })
+    })
+
+    it('devrait créer un événement de création si la ressource a un parent', async () => {
+      resourceService.getById.mockResolvedValue({ name: 'Parent circle' } as never)
+      const manager = buildManager()
+      const event = {
+        entity: { id: 'res-1', ownerId: 'owner-1', parentId: 'parent-1', type: 'EXERCISE', name: 'Exo' },
+        manager,
+      }
+
+      await subscriber.afterInsert(event as never)
+
+      expect(resourceService.getById).toHaveBeenCalledWith('parent-1')
+      expect(manager.save).toHaveBeenCalledTimes(2)
+      expect(manager.create).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ type: ResourceEventTypes.RESOURCE_CREATE })
+      )
+    })
+
+    it("ne devrait pas créer d'événement si la ressource n'a pas de parent", async () => {
+      const manager = buildManager()
+      const event = { entity: { id: 'res-1', ownerId: 'owner-1' }, manager }
+
+      await subscriber.afterInsert(event as never)
+
+      expect(resourceService.getById).not.toHaveBeenCalled()
+      expect(manager.save).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  describe('afterUpdate', () => {
+    it("ne devrait rien faire si le statut n'a pas changé", async () => {
+      const manager = buildManager()
+      const event = { entity: { id: 'res-1' }, updatedColumns: [{ propertyName: 'name' }], manager }
+
+      await subscriber.afterUpdate(event as never)
+
+      expect(manager.save).not.toHaveBeenCalled()
+    })
+
+    it('devrait créer un événement de changement de statut', async () => {
+      resourceService.getById.mockResolvedValue({ name: 'Parent circle' } as never)
+      const manager = buildManager()
+      const event = {
+        entity: { id: 'res-1', type: 'EXERCISE', name: 'Exo', status: 'READY', parentId: undefined },
+        updatedColumns: [{ propertyName: 'status' }],
+        manager,
+      }
+
+      await subscriber.afterUpdate(event as never)
+
+      expect(manager.save).toHaveBeenCalledTimes(1)
+      expect(manager.create).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ type: ResourceEventTypes.RESOURCE_STATUS_CHANGE, actorId: 'user-1' })
+      )
+    })
+
+    it('devrait aussi créer un événement pour le parent si parentId est défini', async () => {
+      resourceService.getById.mockResolvedValue({ name: 'Parent circle' } as never)
+      const manager = buildManager()
+      const event = {
+        entity: {
+          id: 'res-1',
+          type: 'EXERCISE',
+          name: 'Exo',
+          status: 'READY',
+          parentId: 'parent-1',
+          parentName: 'Parent circle',
+        },
+        updatedColumns: [{ propertyName: 'status' }],
+        manager,
+      }
+
+      await subscriber.afterUpdate(event as never)
+
+      expect(manager.save).toHaveBeenCalledTimes(2)
+    })
+  })
+})

--- a/libs/feature/resource/server/src/lib/resource.subscriber.ts
+++ b/libs/feature/resource/server/src/lib/resource.subscriber.ts
@@ -59,7 +59,9 @@ export class ResourceSubscriber implements EntitySubscriberInterface<ResourceEnt
         resourceId: event.entity['id'],
         resourceType: event.entity['type'],
         resourceName: event.entity['name'],
-        parentName: (await this.resourceService.getById(event.entity['parentId'])).name || 'Inconnu',
+        parentName: event.entity['parentId']
+          ? (await this.resourceService.getById(event.entity['parentId'])).name || 'Inconnu'
+          : 'Inconnu',
         newStatus: event.entity['status'],
       }
       await event.manager.save(

--- a/libs/feature/resource/server/src/lib/resource.subscribers.integration.spec.ts
+++ b/libs/feature/resource/server/src/lib/resource.subscribers.integration.spec.ts
@@ -1,0 +1,242 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { IRequest, LevelEntity, TopicEntity, UserEntity } from '@platon/core/server'
+import { UserRoles } from '@platon/core/common'
+import { createTestDatabase, TestDatabase } from '@platon/core/testing/server'
+import { ResourceEventTypes, ResourceStatus, ResourceTypes } from '@platon/feature/resource/common'
+import { DataSource, Repository } from 'typeorm'
+import { ResourceEventEntity } from './events/event.entity'
+import { ResourceEventSubscriber } from './events/event.subscriber'
+import { ResourceInvitationEntity } from './invitations/invitation.entity'
+import { ResourceInvitationSubscriber } from './invitations/invitation.subscriber'
+import { ResourceMemberEntity } from './members/member.entity'
+import { ResourceMemberSubscriber } from './members/member.subscriber'
+import { ResourceMetaEntity } from './metadata/metadata.entity'
+import { ResourceEntity } from './resource.entity'
+import { ResourceService } from './resource.service'
+import { ResourceSubscriber } from './resource.subscriber'
+import { ResourceWatcherEntity } from './watchers/watcher.entity'
+
+/**
+ * Contrairement à resource.service.integration.spec.ts, ce fichier vérifie que les 5 subscribers
+ * TypeORM se déclenchent réellement (dataSource.subscribers) sur de vrais événements insert/update/
+ * remove — pas des InsertEvent/UpdateEvent fabriqués à la main comme dans les specs unitaires.
+ * ResourceStatsSubscriber est volontairement exclu : il rafraîchit une vue matérialisée définie par
+ * migration, absente ici (voir sa propre spec unitaire pour sa logique).
+ */
+describe('Resource subscribers (integration)', () => {
+  let testDb: TestDatabase
+  let dataSource: DataSource
+  let userRepo: Repository<UserEntity>
+  let resourceRepo: Repository<ResourceEntity>
+  let memberRepo: Repository<ResourceMemberEntity>
+  let watcherRepo: Repository<ResourceWatcherEntity>
+  let eventRepo: Repository<ResourceEventEntity>
+  let request: { user: { id: string } }
+  let notificationService: { sendToAllUsers: jest.Mock; sendToUser: jest.Mock; deleteWhere: jest.Mock }
+
+  beforeAll(async () => {
+    testDb = await createTestDatabase([
+      UserEntity,
+      LevelEntity,
+      TopicEntity,
+      ResourceEntity,
+      ResourceMemberEntity,
+      ResourceWatcherEntity,
+      ResourceMetaEntity,
+      ResourceEventEntity,
+      ResourceInvitationEntity,
+    ])
+    dataSource = testDb.dataSource
+    userRepo = dataSource.getRepository(UserEntity)
+    resourceRepo = dataSource.getRepository(ResourceEntity)
+    memberRepo = dataSource.getRepository(ResourceMemberEntity)
+    watcherRepo = dataSource.getRepository(ResourceWatcherEntity)
+    eventRepo = dataSource.getRepository<ResourceEventEntity>(ResourceEventEntity)
+
+    const resourceService = new ResourceService(
+      resourceRepo,
+      dataSource.getRepository(ResourceMetaEntity),
+      dataSource,
+      { findById: jest.fn(), findAll: jest.fn() } as any,
+      { findById: jest.fn(), findAll: jest.fn() } as any,
+      { emit: jest.fn() } as any
+    )
+
+    request = { user: { id: '' } }
+    notificationService = {
+      sendToAllUsers: jest.fn().mockResolvedValue(undefined),
+      sendToUser: jest.fn().mockResolvedValue(undefined),
+      deleteWhere: jest.fn().mockResolvedValue(0),
+    }
+
+    // Chaque constructeur s'enregistre lui-même sur dataSource.subscribers — c'est exactement
+    // ce que fait Nest au bootstrap en production, une fois par provider.
+    new ResourceSubscriber(resourceService, dataSource, request as unknown as IRequest)
+    new ResourceMemberSubscriber(dataSource)
+    new ResourceEventSubscriber(
+      dataSource,
+      { search: jest.fn().mockResolvedValue([[], 0]) } as any,
+      resourceService,
+      notificationService as any
+    )
+    new ResourceInvitationSubscriber(dataSource, notificationService as any)
+  }, 60_000)
+
+  afterAll(async () => {
+    await testDb.teardown()
+  })
+
+  afterEach(async () => {
+    jest.clearAllMocks()
+    await dataSource.query('TRUNCATE "ResourceInvitations" CASCADE')
+    await dataSource.query('TRUNCATE "ResourceEvents" CASCADE')
+    await dataSource.query('TRUNCATE "ResourceMembers" CASCADE')
+    await dataSource.query('TRUNCATE "ResourceWatchers" CASCADE')
+    await dataSource.query('TRUNCATE "Resources" CASCADE')
+    await dataSource.query('TRUNCATE "Users" CASCADE')
+  })
+
+  let userCounter = 0
+  const seedUser = async (): Promise<UserEntity> => {
+    userCounter++
+    return userRepo.save(
+      userRepo.create({
+        username: `sub-integration-user-${userCounter}`,
+        firstName: 'Test',
+        lastName: 'User',
+        email: `sub-integration-user-${userCounter}@test.local`,
+        role: UserRoles.teacher,
+        active: true,
+        lastActivity: new Date(),
+      })
+    )
+  }
+
+  const seedResource = async (overrides: Partial<ResourceEntity> = {}): Promise<ResourceEntity> => {
+    return resourceRepo.save(
+      resourceRepo.create({
+        name: 'Resource',
+        type: ResourceTypes.CIRCLE,
+        status: ResourceStatus.READY,
+        personal: false,
+        ...overrides,
+      })
+    )
+  }
+
+  describe('ResourceSubscriber', () => {
+    it("devrait auto-créer un watcher pour le propriétaire à l'insertion d'une ressource", async () => {
+      const owner = await seedUser()
+
+      const resource = await seedResource({ ownerId: owner.id })
+
+      const watcher = await watcherRepo.findOne({ where: { resourceId: resource.id, userId: owner.id } })
+      expect(watcher).not.toBeNull()
+    })
+
+    it('devrait journaliser un événement de création sur le parent quand la ressource en a un', async () => {
+      const owner = await seedUser()
+      const parent = await seedResource({ ownerId: owner.id })
+
+      const child = await seedResource({ ownerId: owner.id, parentId: parent.id } as never)
+
+      const events = await eventRepo.find({
+        where: { resourceId: parent.id, type: ResourceEventTypes.RESOURCE_CREATE },
+      })
+      expect(events).toHaveLength(1)
+      expect(notificationService.sendToAllUsers).toHaveBeenCalled()
+      void child
+    })
+
+    it('devrait journaliser un événement au changement de statut', async () => {
+      const owner = await seedUser()
+      request.user.id = owner.id
+      const resource = await seedResource({ ownerId: owner.id, status: ResourceStatus.DRAFT })
+
+      resource.status = ResourceStatus.READY
+      await resourceRepo.save(resource)
+
+      const events = await eventRepo.find({
+        where: { resourceId: resource.id, type: ResourceEventTypes.RESOURCE_STATUS_CHANGE },
+      })
+      expect(events).toHaveLength(1)
+    })
+  })
+
+  describe('ResourceMemberSubscriber', () => {
+    it("devrait journaliser l'adhésion et créer un watcher pour un membre en attente", async () => {
+      const owner = await seedUser()
+      const member = await seedUser()
+      const resource = await seedResource({ ownerId: owner.id })
+
+      await memberRepo.save(
+        memberRepo.create({ resourceId: resource.id, userId: member.id, inviterId: owner.id, waiting: true })
+      )
+
+      const events = await eventRepo.find({
+        where: { resourceId: resource.id, type: ResourceEventTypes.MEMBER_CREATE },
+      })
+      expect(events).toHaveLength(1)
+      const watcher = await watcherRepo.findOne({ where: { resourceId: resource.id, userId: member.id } })
+      expect(watcher).not.toBeNull()
+    })
+
+    it('devrait supprimer le watcher associé et journaliser le départ à la suppression du membre', async () => {
+      const owner = await seedUser()
+      const member = await seedUser()
+      const resource = await seedResource({ ownerId: owner.id })
+      const savedMember = await memberRepo.save(
+        memberRepo.create({ resourceId: resource.id, userId: member.id, inviterId: owner.id, waiting: true })
+      )
+      jest.clearAllMocks()
+
+      await memberRepo.remove(savedMember)
+
+      const watcher = await watcherRepo.findOne({ where: { resourceId: resource.id, userId: member.id } })
+      expect(watcher).toBeNull()
+      const events = await eventRepo.find({
+        where: { resourceId: resource.id, type: ResourceEventTypes.MEMBER_REMOVE },
+      })
+      expect(events).toHaveLength(1)
+    })
+  })
+
+  describe('ResourceEventSubscriber (notifications)', () => {
+    it("devrait déclencher une notification lorsqu'un événement est journalisé", async () => {
+      const owner = await seedUser()
+      const member = await seedUser()
+      const resource = await seedResource({ ownerId: owner.id })
+
+      await memberRepo.save(
+        memberRepo.create({ resourceId: resource.id, userId: member.id, inviterId: owner.id, waiting: false })
+      )
+
+      expect(notificationService.sendToAllUsers).toHaveBeenCalledWith(
+        expect.any(Array),
+        expect.objectContaining({ type: 'RESOURCE-EVENT' })
+      )
+    })
+  })
+
+  describe('ResourceInvitationSubscriber', () => {
+    it("devrait notifier l'invité à la création d'une invitation", async () => {
+      const inviter = await seedUser()
+      const invitee = await seedUser()
+      const resource = await seedResource({ ownerId: inviter.id })
+
+      await dataSource.getRepository(ResourceInvitationEntity).save(
+        dataSource.getRepository(ResourceInvitationEntity).create({
+          inviterId: inviter.id,
+          inviteeId: invitee.id,
+          resourceId: resource.id,
+          permissions: { read: true, write: false },
+        })
+      )
+
+      expect(notificationService.sendToUser).toHaveBeenCalledWith(
+        invitee.id,
+        expect.objectContaining({ type: 'RESOURCE-INVITATION' })
+      )
+    })
+  })
+})

--- a/libs/feature/resource/server/src/lib/statistics/statistic.subscriber.spec.ts
+++ b/libs/feature/resource/server/src/lib/statistics/statistic.subscriber.spec.ts
@@ -1,0 +1,68 @@
+import { DataSource } from 'typeorm'
+import { ResourceStatsSubscriber } from './statistic.subscriber'
+
+describe('ResourceStatsSubscriber', () => {
+  let subscriber: ResourceStatsSubscriber
+  let dataSource: { subscribers: unknown[]; query: jest.Mock }
+
+  beforeEach(() => {
+    dataSource = { subscribers: [], query: jest.fn().mockResolvedValue(undefined) }
+    subscriber = new ResourceStatsSubscriber(dataSource as unknown as DataSource)
+  })
+
+  it("devrait s'enregistrer lui-même auprès du DataSource", () => {
+    expect(dataSource.subscribers).toContain(subscriber)
+  })
+
+  describe('afterInsert / afterUpdate / afterRemove', () => {
+    const buildEvent = (tableName: string) => ({
+      metadata: { tableName },
+      manager: { query: jest.fn().mockResolvedValue(undefined) },
+    })
+
+    it('devrait rafraîchir la vue matérialisée pour une table surveillée', async () => {
+      const event = buildEvent('Resources')
+
+      await subscriber.afterInsert(event as never)
+
+      expect(event.manager.query).toHaveBeenCalledWith('REFRESH MATERIALIZED VIEW "ResourceStats"')
+    })
+
+    it('ne devrait rien faire pour une table non surveillée', async () => {
+      const event = buildEvent('SomeOtherTable')
+
+      await subscriber.afterUpdate(event as never)
+
+      expect(event.manager.query).not.toHaveBeenCalled()
+    })
+
+    it('afterRemove devrait aussi rafraîchir la vue pour une table surveillée', async () => {
+      const event = buildEvent('ResourceMembers')
+
+      await subscriber.afterRemove(event as never)
+
+      expect(event.manager.query).toHaveBeenCalled()
+    })
+  })
+
+  describe('onChangeFile', () => {
+    it('devrait mettre à jour la date de la ressource puis rafraîchir la vue', async () => {
+      await (subscriber as never as { onChangeFile: (p: unknown) => Promise<void> }).onChangeFile({
+        resource: { id: 'resource-1' },
+      })
+
+      expect(dataSource.query).toHaveBeenCalledWith(expect.stringContaining('UPDATE "Resources"'), ['resource-1'])
+      expect(dataSource.query).toHaveBeenCalledWith('REFRESH MATERIALIZED VIEW "ResourceStats"')
+    })
+
+    it('ne devrait pas laisser fuiter une erreur', async () => {
+      dataSource.query.mockRejectedValue(new Error('db error'))
+
+      await expect(
+        (subscriber as never as { onChangeFile: (p: unknown) => Promise<void> }).onChangeFile({
+          resource: { id: 'resource-1' },
+        })
+      ).resolves.toBeUndefined()
+    })
+  })
+})

--- a/libs/feature/resource/server/src/lib/user/user.controller.spec.ts
+++ b/libs/feature/resource/server/src/lib/user/user.controller.spec.ts
@@ -1,0 +1,62 @@
+import { UnauthorizedException } from '@nestjs/common'
+import { Test, TestingModule } from '@nestjs/testing'
+import { IRequest } from '@platon/core/server'
+import { createUserEntity } from '@platon/core/testing/server'
+import { ResourceInvitationService } from '../invitations'
+import { ResourceEntity } from '../resource.entity'
+import { ResourceService } from '../resource.service'
+import { UserResourceController } from './user.controller'
+
+describe('UserResourceController', () => {
+  let controller: UserResourceController
+  let resourceService: jest.Mocked<ResourceService>
+  let invitationService: jest.Mocked<ResourceInvitationService>
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [UserResourceController],
+      providers: [
+        { provide: ResourceService, useValue: { getPersonal: jest.fn() } },
+        { provide: ResourceInvitationService, useValue: { findAllByInviteeId: jest.fn() } },
+      ],
+    }).compile()
+
+    controller = module.get(UserResourceController)
+    resourceService = module.get(ResourceService)
+    invitationService = module.get(ResourceInvitationService)
+  })
+
+  describe('circle', () => {
+    it("devrait rejeter si le username ne correspond pas à l'utilisateur connecté", async () => {
+      const req = { user: createUserEntity({ username: 'testuser' }) } as unknown as IRequest
+
+      await expect(controller.circle(req, 'someone-else')).rejects.toBeInstanceOf(UnauthorizedException)
+    })
+
+    it('devrait retourner le cercle personnel avec des permissions complètes', async () => {
+      const user = createUserEntity({ username: 'testuser' })
+      const req = { user } as unknown as IRequest
+      resourceService.getPersonal.mockResolvedValue({ id: 'circle-1' } as ResourceEntity)
+
+      const result = await controller.circle(req, 'testuser')
+
+      expect(resourceService.getPersonal).toHaveBeenCalledWith(user)
+      expect((result.resource as never as { permissions: { read: boolean; write: boolean } }).permissions).toEqual({
+        read: true,
+        write: true,
+      })
+    })
+  })
+
+  describe('invitations', () => {
+    it("devrait retourner les invitations de l'utilisateur courant", async () => {
+      const req = { user: createUserEntity({ id: 'user-1' }) } as unknown as IRequest
+      invitationService.findAllByInviteeId.mockResolvedValue([[{ resourceId: 'r1' } as never], 1])
+
+      const result = await controller.invitations(req)
+
+      expect(invitationService.findAllByInviteeId).toHaveBeenCalledWith('user-1')
+      expect(result.total).toBe(1)
+    })
+  })
+})

--- a/libs/feature/resource/server/src/lib/views/view.service.spec.ts
+++ b/libs/feature/resource/server/src/lib/views/view.service.spec.ts
@@ -1,0 +1,85 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { getRepositoryToken } from '@nestjs/typeorm'
+import { MockRepository, mockRepository } from '@platon/core/testing/server'
+import { In } from 'typeorm'
+import { ResourceViewEntity } from './view.entity'
+import { ResourceViewService } from './view.service'
+
+describe('ResourceViewService', () => {
+  let service: ResourceViewService
+  let repository: MockRepository<ResourceViewEntity>
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ResourceViewService,
+        { provide: getRepositoryToken(ResourceViewEntity), useValue: mockRepository<ResourceViewEntity>() },
+      ],
+    }).compile()
+
+    service = module.get(ResourceViewService)
+    repository = module.get(getRepositoryToken(ResourceViewEntity))
+  })
+
+  describe('findAll', () => {
+    it('devrait lister les vues avec la ressource associée, triées par date décroissante', async () => {
+      repository.findAndCount.mockResolvedValue([[], 0])
+
+      await service.findAll('user-1')
+
+      expect(repository.findAndCount).toHaveBeenCalledWith({
+        where: { userId: 'user-1' },
+        relations: { resource: true },
+        order: { updatedAt: 'DESC' },
+      })
+    })
+  })
+
+  describe('create', () => {
+    it("devrait rafraîchir la date de la vue existante plutôt que d'en créer une nouvelle", async () => {
+      const lastView = {
+        userId: 'user-1',
+        resourceId: 'resource-1',
+        updatedAt: new Date('2020-01-01'),
+      } as ResourceViewEntity
+      repository.findOne.mockResolvedValue(lastView)
+      repository.save.mockResolvedValue(lastView)
+
+      await service.create({ userId: 'user-1', resourceId: 'resource-1' })
+
+      expect(repository.save).toHaveBeenCalledWith(lastView)
+      expect(repository.find).not.toHaveBeenCalled()
+    })
+
+    it("devrait créer une nouvelle vue si aucune n'existe pour cette ressource", async () => {
+      repository.findOne.mockResolvedValue(null)
+      repository.find.mockResolvedValue([{ id: 'view-1' } as ResourceViewEntity])
+
+      await service.create({ userId: 'user-1', resourceId: 'resource-1' })
+
+      expect(repository.save).toHaveBeenCalledWith({ userId: 'user-1', resourceId: 'resource-1' })
+    })
+
+    it('devrait supprimer les vues excédentaires au-delà de 5 par utilisateur', async () => {
+      repository.findOne.mockResolvedValue(null)
+      const views = Array.from({ length: 7 }, (_, i) => ({ id: `view-${i}` } as ResourceViewEntity))
+      repository.find.mockResolvedValue(views)
+
+      await service.create({ userId: 'user-1', resourceId: 'resource-1' })
+
+      expect(repository.delete).toHaveBeenCalledWith({
+        userId: 'user-1',
+        id: In(['view-5', 'view-6']),
+      })
+    })
+
+    it('ne devrait rien supprimer si le nombre de vues ne dépasse pas la limite', async () => {
+      repository.findOne.mockResolvedValue(null)
+      repository.find.mockResolvedValue([{ id: 'view-1' } as ResourceViewEntity])
+
+      await service.create({ userId: 'user-1', resourceId: 'resource-1' })
+
+      expect(repository.delete).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/libs/feature/resource/server/src/lib/watchers/watcher.controller.spec.ts
+++ b/libs/feature/resource/server/src/lib/watchers/watcher.controller.spec.ts
@@ -1,0 +1,86 @@
+import { UnauthorizedException } from '@nestjs/common'
+import { Test, TestingModule } from '@nestjs/testing'
+import { NotFoundResponse } from '@platon/core/common'
+import { IRequest } from '@platon/core/server'
+import { createUserEntity } from '@platon/core/testing/server'
+import { Optional } from 'typescript-optional'
+import { ResourceWatcherController } from './watcher.controller'
+import { ResourceWatcherEntity } from './watcher.entity'
+import { ResourceWatcherService } from './watcher.service'
+
+describe('ResourceWatcherController', () => {
+  let controller: ResourceWatcherController
+  let service: jest.Mocked<ResourceWatcherService>
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [ResourceWatcherController],
+      providers: [
+        {
+          provide: ResourceWatcherService,
+          useValue: { search: jest.fn(), findByUserId: jest.fn(), create: jest.fn(), deleteByUserId: jest.fn() },
+        },
+      ],
+    }).compile()
+
+    controller = module.get(ResourceWatcherController)
+    service = module.get(ResourceWatcherService)
+  })
+
+  describe('search', () => {
+    it('devrait retourner les utilisateurs qui suivent la ressource', async () => {
+      const user = createUserEntity({ username: 'watcher1' })
+      service.search.mockResolvedValue([[{ user } as unknown as ResourceWatcherEntity], 1])
+
+      const result = await controller.search('r1', {})
+
+      expect(result.total).toBe(1)
+      expect(result.resources[0].username).toBe('watcher1')
+    })
+  })
+
+  describe('find', () => {
+    it('devrait rejeter avec NotFoundResponse si le suivi est introuvable', async () => {
+      service.findByUserId.mockResolvedValue(Optional.empty())
+
+      await expect(controller.find('r1', 'u1')).rejects.toBeInstanceOf(NotFoundResponse)
+    })
+
+    it("devrait retourner l'utilisateur qui suit la ressource", async () => {
+      const user = createUserEntity({ username: 'watcher1' })
+      service.findByUserId.mockResolvedValue(Optional.of({ user } as unknown as ResourceWatcherEntity))
+
+      const result = await controller.find('r1', 'u1')
+
+      expect(result.resource.username).toBe('watcher1')
+    })
+  })
+
+  describe('create', () => {
+    it("devrait créer le suivi pour l'utilisateur courant", async () => {
+      const req = { user: { id: 'user-1' } } as unknown as IRequest
+      service.create.mockResolvedValue({ userId: 'user-1', resourceId: 'r1' } as ResourceWatcherEntity)
+
+      await controller.create(req, 'r1')
+
+      expect(service.create).toHaveBeenCalledWith({ userId: 'user-1', resourceId: 'r1' })
+    })
+  })
+
+  describe('delete', () => {
+    it("devrait rejeter si l'utilisateur tente de supprimer le suivi de quelqu'un d'autre", async () => {
+      const req = { user: { id: 'user-1' } } as unknown as IRequest
+
+      await expect(controller.delete(req, 'someone-else', 'r1')).rejects.toBeInstanceOf(UnauthorizedException)
+      expect(service.deleteByUserId).not.toHaveBeenCalled()
+    })
+
+    it('devrait supprimer son propre suivi', async () => {
+      const req = { user: { id: 'user-1' } } as unknown as IRequest
+
+      await controller.delete(req, 'user-1', 'r1')
+
+      expect(service.deleteByUserId).toHaveBeenCalledWith('r1', 'user-1')
+    })
+  })
+})

--- a/libs/feature/resource/server/src/lib/watchers/watcher.service.spec.ts
+++ b/libs/feature/resource/server/src/lib/watchers/watcher.service.spec.ts
@@ -1,0 +1,137 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { getRepositoryToken } from '@nestjs/typeorm'
+import { NotFoundResponse, UserOrderings } from '@platon/core/common'
+import { MockRepository, mockRepository, mockSelectQueryBuilder } from '@platon/core/testing/server'
+import { ResourceWatcherEntity } from './watcher.entity'
+import { ResourceWatcherService } from './watcher.service'
+
+describe('ResourceWatcherService', () => {
+  let service: ResourceWatcherService
+  let repository: MockRepository<ResourceWatcherEntity>
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        ResourceWatcherService,
+        { provide: getRepositoryToken(ResourceWatcherEntity), useValue: mockRepository<ResourceWatcherEntity>() },
+      ],
+    }).compile()
+
+    service = module.get(ResourceWatcherService)
+    repository = module.get(getRepositoryToken(ResourceWatcherEntity))
+  })
+
+  describe('findByUserId', () => {
+    it('devrait retourner Optional.of(watcher) avec sa relation user', async () => {
+      const watcher = { resourceId: 'r1', userId: 'u1' } as ResourceWatcherEntity
+      repository.findOne.mockResolvedValue(watcher)
+
+      const result = await service.findByUserId('r1', 'u1')
+
+      expect(repository.findOne).toHaveBeenCalledWith({
+        where: { resourceId: 'r1', userId: 'u1' },
+        relations: { user: true },
+      })
+      expect(result.get()).toBe(watcher)
+    })
+
+    it('devrait retourner Optional.empty() si non trouvé', async () => {
+      repository.findOne.mockResolvedValue(null)
+
+      const result = await service.findByUserId('r1', 'unknown')
+
+      expect(result.isPresent()).toBe(false)
+    })
+  })
+
+  describe('findAllByUserId', () => {
+    it("devrait retourner tous les suivis de l'utilisateur", async () => {
+      repository.find.mockResolvedValue([])
+
+      await service.findAllByUserId('u1')
+
+      expect(repository.find).toHaveBeenCalledWith({ where: { userId: 'u1' } })
+    })
+  })
+
+  describe('search', () => {
+    it('devrait trier par nom par défaut (multi-clé)', async () => {
+      const qb = mockSelectQueryBuilder<ResourceWatcherEntity>()
+      repository.createQueryBuilder.mockReturnValue(qb)
+
+      await service.search('r1')
+
+      expect(qb.where).toHaveBeenCalledWith('watcher.resource_id = :resourceId', { resourceId: 'r1' })
+      expect(qb.orderBy).toHaveBeenCalledWith('user.last_name', 'ASC')
+      expect(qb.addOrderBy).toHaveBeenNthCalledWith(1, 'user.first_name', 'ASC')
+      expect(qb.addOrderBy).toHaveBeenNthCalledWith(2, 'user.username', 'ASC')
+    })
+
+    it('devrait filtrer par texte de recherche avec f_unaccent', async () => {
+      const qb = mockSelectQueryBuilder<ResourceWatcherEntity>()
+      repository.createQueryBuilder.mockReturnValue(qb)
+
+      await service.search('r1', { search: '  jean  ' })
+
+      expect(qb.andWhere).toHaveBeenCalledWith(expect.stringContaining('f_unaccent'), { search: '%jean%' })
+    })
+
+    it('devrait trier sur un autre champ que NAME sans addOrderBy', async () => {
+      const qb = mockSelectQueryBuilder<ResourceWatcherEntity>()
+      repository.createQueryBuilder.mockReturnValue(qb)
+
+      await service.search('r1', { order: UserOrderings.UPDATED_AT })
+
+      expect(qb.orderBy).toHaveBeenCalledWith('watcher.updated_at', 'DESC')
+      expect(qb.addOrderBy).not.toHaveBeenCalled()
+    })
+
+    it('devrait appliquer offset et limit', async () => {
+      const qb = mockSelectQueryBuilder<ResourceWatcherEntity>()
+      repository.createQueryBuilder.mockReturnValue(qb)
+
+      await service.search('r1', { offset: 3, limit: 7 })
+
+      expect(qb.offset).toHaveBeenCalledWith(3)
+      expect(qb.limit).toHaveBeenCalledWith(7)
+    })
+  })
+
+  describe('create', () => {
+    it('devrait créer le suivi', async () => {
+      const created = { resourceId: 'r1', userId: 'u1' } as ResourceWatcherEntity
+      repository.create.mockReturnValue(created)
+      repository.save.mockResolvedValue(created)
+
+      const result = await service.create({ resourceId: 'r1', userId: 'u1' })
+
+      expect(result).toBe(created)
+    })
+  })
+
+  describe('updateByUserId', () => {
+    it("devrait rejeter avec NotFoundResponse si le suivi n'existe pas", async () => {
+      repository.findOne.mockResolvedValue(null)
+
+      await expect(service.updateByUserId('r1', 'u1', {})).rejects.toBeInstanceOf(NotFoundResponse)
+    })
+
+    it('devrait fusionner les changements et sauvegarder', async () => {
+      const watcher = { resourceId: 'r1', userId: 'u1' } as ResourceWatcherEntity
+      repository.findOne.mockResolvedValue(watcher)
+      repository.save.mockImplementation(async (w) => w as ResourceWatcherEntity)
+
+      const result = await service.updateByUserId('r1', 'u1', { resourceId: 'r1' })
+
+      expect(result).toBeDefined()
+    })
+  })
+
+  describe('deleteByUserId', () => {
+    it('devrait supprimer par resourceId et userId', async () => {
+      await service.deleteByUserId('r1', 'u1')
+
+      expect(repository.delete).toHaveBeenCalledWith({ resourceId: 'r1', userId: 'u1' })
+    })
+  })
+})

--- a/libs/feature/resource/server/src/lib/watchers/watcher.service.ts
+++ b/libs/feature/resource/server/src/lib/watchers/watcher.service.ts
@@ -49,7 +49,7 @@ export class ResourceWatcherService {
 
     const order = filters.order || UserOrderings.NAME
     const direction = filters.direction || USER_ORDERING_DIRECTIONS[order]
-    if (filters.order === UserOrderings.NAME) {
+    if (order === UserOrderings.NAME) {
       query
         .orderBy('user.last_name', direction)
         .addOrderBy('user.first_name', direction)

--- a/libs/feature/resource/server/tsconfig.integration.json
+++ b/libs/feature/resource/server/tsconfig.integration.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "module": "commonjs",
+    "target": "es2018",
+    "types": ["jest", "node"],
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true
+  },
+  "include": ["jest.integration.config.ts", "src/**/*.integration.spec.ts", "src/**/*.d.ts"]
+}


### PR DESCRIPTION
This pull request introduces significant improvements to the testing infrastructure and coverage for the resource feature, particularly focusing on dependency and event management. It enhances the test utilities for TypeORM repositories and query builders, adds comprehensive unit tests for key services and subscribers, and refines the Jest configuration to better separate and run different test types.

**Testing Infrastructure Enhancements**

- Extended the `createTestDatabase` utility to accept raw SQL setup instructions (`setupSql`), allowing for more flexible test database initialization, such as adding extensions or views not covered by schema synchronization. [[1]](diffhunk://#diff-503e422f19ffbbadc37f6658aae072cf5d4ea40ed3e71fa8f5d58431bd2f6f17R18-R24) [[2]](diffhunk://#diff-503e422f19ffbbadc37f6658aae072cf5d4ea40ed3e71fa8f5d58431bd2f6f17R47-R50)
- Improved mock utilities for TypeORM:
  - `mockSelectQueryBuilder` now mocks additional methods (`distinct`, `getOneOrFail`) for more complete query builder testing.
  - `MockRepository` and `mockRepository` now support `findBy` and `findOneOrFail`, expanding the range of repository methods that can be tested. [[1]](diffhunk://#diff-48a51f283371274d5b73363dcc686b4c7584600d9312bc85a81c3a17c0d1340bR11-R14) [[2]](diffhunk://#diff-48a51f283371274d5b73363dcc686b4c7584600d9312bc85a81c3a17c0d1340bR28-R31)

**Jest Configuration and Project Scripts**

- Updated the Jest config for the resource server to ignore integration and e2e tests in the standard test run.
- Added a dedicated Jest configuration for integration tests and corresponding Nx project targets, including a `test:all` script to run both unit and integration tests sequentially. [[1]](diffhunk://#diff-f545c32529e60236db1068cfd399dd1fdbc5eac2ff026d0b022b58c4692d4a16R1-R18) [[2]](diffhunk://#diff-bdba76ce9066e105011cfb19725bd0001e23afef789a87433f3975d86a03e20bR17-R31)

**Test Coverage Improvements**

- Added comprehensive unit tests for `ResourceDependencyService`, covering all major methods and edge cases.
- Implemented unit tests for `ResourceEventController` and `ResourceEventService`, verifying delegation, filtering, and result mapping. [[1]](diffhunk://#diff-c37cff7c9f3aa84b4d605b07502a5a7cdb5356737d9f11cba400a016fc45d0e0R1-R30) [[2]](diffhunk://#diff-7498559c4d0eeb4ed287cb6e2762b1a804e31ca6bc34879ae64cc785015847cfR1-R55)
- Introduced tests for `ResourceEventSubscriber`, ensuring correct notification logic and robust error handling during event processing.