### PR TITLE
Test/coverage cas server

### DIFF
--- a/apps/web/src/app/pages/editor/contributions/editors/pla-editor/pla-editor.component.ts
+++ b/apps/web/src/app/pages/editor/contributions/editors/pla-editor/pla-editor.component.ts
@@ -355,7 +355,7 @@ export class PlaEditorComponent implements OnInit, OnDestroy {
         this.form.get('nextSettings.hasExercisesVariables')?.setValue(true, { emitEvent: false })
         this.exerciseGroups.forEach((group) => {
           if (!group.grader || group.grader.type === 'empty') {
-            group.grader = this.defaultGrader
+            group.grader = { ...this.defaultGrader }
           }
         })
       }
@@ -554,7 +554,7 @@ export class PlaEditorComponent implements OnInit, OnDestroy {
 
   protected addGroup(name?: string): void {
     const initialGrader: GroupGrader =
-      this.activity?.settings?.navigation?.mode === 'validation' ? this.defaultGrader : { type: 'empty' }
+      this.activity?.settings?.navigation?.mode === 'validation' ? { ...this.defaultGrader } : { type: 'empty' }
     if (name) {
       if (this.exerciseGroups.find((group) => group.name === name)) {
         return // prevent adding a group with the same name
@@ -833,7 +833,7 @@ export class PlaEditorComponent implements OnInit, OnDestroy {
     if (type === 'empty') {
       group.grader = { type: 'empty' }
     } else if (type === 'mean' || type === 'success') {
-      group.grader = this.defaultGrader
+      group.grader = { ...group.grader, type }
     }
     this.onChangeData()
   }

--- a/libs/feature/cas/server/jest.config.ts
+++ b/libs/feature/cas/server/jest.config.ts
@@ -1,6 +1,7 @@
 module.exports = {
   displayName: 'feature-cas-server',
   preset: '../../../../jest.preset.js',
+  testPathIgnorePatterns: ['/node_modules/', '\\.integration\\.spec\\.ts$', '\\.e2e\\.spec\\.ts$'],
   testEnvironment: 'node',
   transform: {
     '^.+\\.ts$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],

--- a/libs/feature/cas/server/jest.integration.config.ts
+++ b/libs/feature/cas/server/jest.integration.config.ts
@@ -1,0 +1,18 @@
+export default {
+  displayName: 'feature-cas-server-integration',
+  preset: '../../../../jest.preset.js',
+  testMatch: ['**/*.integration.spec.ts'],
+  testTimeout: 60_000,
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.ts$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.integration.json' }],
+    '^.+\\.js$': [
+      '@swc/jest',
+      {
+        jsc: { target: 'es2022', parser: { syntax: 'ecmascript' } },
+        module: { type: 'commonjs' },
+      },
+    ],
+  },
+  coverageDirectory: '../../../../coverage/libs/feature/cas/server/integration',
+}

--- a/libs/feature/cas/server/project.json
+++ b/libs/feature/cas/server/project.json
@@ -25,6 +25,21 @@
           "codeCoverage": true
         }
       }
+    },
+    "test:integration": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}/integration"],
+      "options": {
+        "jestConfig": "libs/feature/cas/server/jest.integration.config.ts",
+        "passWithNoTests": false
+      }
+    },
+    "test:all": {
+      "executor": "nx:run-commands",
+      "options": {
+        "commands": ["nx run feature-cas-server:test", "nx run feature-cas-server:test:integration"],
+        "parallel": false
+      }
     }
   }
 }

--- a/libs/feature/cas/server/src/lib/axios.service.spec.ts
+++ b/libs/feature/cas/server/src/lib/axios.service.spec.ts
@@ -1,0 +1,47 @@
+import { ConfigService } from '@nestjs/config'
+import axios from 'axios-https-proxy-fix'
+import { AxiosService } from './axios.service'
+
+jest.mock('axios-https-proxy-fix', () => ({
+  get: jest.fn(),
+}))
+
+describe('AxiosService', () => {
+  const buildConfigService = (values: Record<string, unknown>) =>
+    ({ get: jest.fn((key: string) => values[key]) } as unknown as ConfigService)
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  it("ne devrait pas configurer de proxy si l'hôte ou le port sont absents", async () => {
+    ;(axios.get as jest.Mock).mockResolvedValue({ data: {} })
+    const service = new AxiosService(buildConfigService({}))
+
+    await service.get('https://example.test')
+
+    expect(axios.get).toHaveBeenCalledWith('https://example.test', {})
+  })
+
+  it('devrait configurer le proxy quand host et port sont tous deux définis', async () => {
+    ;(axios.get as jest.Mock).mockResolvedValue({ data: {} })
+    const service = new AxiosService(buildConfigService({ PROXY_CONFIG_HOST: 'proxy.local', PROXY_CONFIG_PORT: 8080 }))
+
+    await service.get('https://example.test')
+
+    expect(axios.get).toHaveBeenCalledWith(
+      'https://example.test',
+      expect.objectContaining({ proxy: { host: 'proxy.local', port: 8080 } })
+    )
+  })
+
+  it('devrait retourner la réponse axios', async () => {
+    const response = { data: { hello: 'world' } }
+    ;(axios.get as jest.Mock).mockResolvedValue(response)
+    const service = new AxiosService(buildConfigService({}))
+
+    const result = await service.get('https://example.test')
+
+    expect(result).toBe(response)
+  })
+})

--- a/libs/feature/cas/server/src/lib/cas.controller.spec.ts
+++ b/libs/feature/cas/server/src/lib/cas.controller.spec.ts
@@ -1,0 +1,222 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { AuthService, UserService } from '@platon/core/server'
+import { NotFoundResponse } from '@platon/core/common'
+import { LTIService } from '@platon/feature/lti/server'
+import { Optional } from 'typescript-optional'
+import { AxiosService } from './axios.service'
+import { CasController } from './cas.controller'
+import { CasEntity } from './entities/cas.entity'
+import { CasService } from './cas.service'
+
+describe('CasController', () => {
+  let controller: CasController
+  let service: jest.Mocked<CasService>
+  let ltiService: jest.Mocked<LTIService>
+  let authService: jest.Mocked<AuthService>
+  let userService: jest.Mocked<UserService>
+  let https: jest.Mocked<AxiosService>
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      controllers: [CasController],
+      providers: [
+        {
+          provide: CasService,
+          useValue: {
+            searchCas: jest.fn(),
+            findCasById: jest.fn(),
+            findCasByName: jest.fn(),
+            createCas: jest.fn(),
+            updateCas: jest.fn(),
+            deleteCas: jest.fn(),
+            fromInput: jest.fn(),
+          },
+        },
+        { provide: LTIService, useValue: { findLmsUserByUsername: jest.fn() } },
+        { provide: AuthService, useValue: { authenticate: jest.fn() } },
+        { provide: UserService, useValue: { findById: jest.fn() } },
+        { provide: AxiosService, useValue: { get: jest.fn() } },
+      ],
+    }).compile()
+
+    controller = module.get(CasController)
+    service = module.get(CasService)
+    ltiService = module.get(LTIService)
+    authService = module.get(AuthService)
+    userService = module.get(UserService)
+    https = module.get(AxiosService)
+  })
+
+  describe('checkCasTicket', () => {
+    it('devrait retourner le username en cas de succès', async () => {
+      https.get.mockResolvedValue({
+        data: { serviceResponse: { authenticationSuccess: { user: 'jdoe' } } },
+      } as never)
+
+      const result = await controller.checkCasTicket('https://cas.test/validate', 'ST-1', 'https://app.test')
+
+      expect(result.get()).toBe('jdoe')
+    })
+
+    it("devrait lever une erreur avec la description en cas d'échec d'authentification CAS", async () => {
+      https.get.mockResolvedValue({
+        data: {
+          serviceResponse: { authenticationFailure: { code: 'INVALID_TICKET', description: 'Ticket invalide' } },
+        },
+      } as never)
+
+      await expect(controller.checkCasTicket('https://cas.test/validate', 'ST-1', 'https://app.test')).rejects.toThrow(
+        'Ticket invalide'
+      )
+    })
+
+    it('devrait retourner Optional.empty() si la réponse ne contient ni succès ni échec', async () => {
+      https.get.mockResolvedValue({ data: { serviceResponse: {} } } as never)
+
+      const result = await controller.checkCasTicket('https://cas.test/validate', 'ST-1', 'https://app.test')
+
+      expect(result.isEmpty()).toBe(true)
+    })
+
+    it('devrait lever une erreur explicite quand le fournisseur CAS est injoignable (erreur réseau)', async () => {
+      https.get.mockRejectedValue(new Error('ECONNREFUSED'))
+
+      await expect(controller.checkCasTicket('https://cas.test/validate', 'ST-1', 'https://app.test')).rejects.toThrow(
+        'Your CAS provider is not accessible'
+      )
+    })
+  })
+
+  describe('listCas', () => {
+    it('devrait retourner uniquement les noms des CAS', async () => {
+      service.searchCas.mockResolvedValue([[{ name: 'univ-a' } as CasEntity, { name: 'univ-b' } as CasEntity], 2])
+
+      const result = await controller.listCas()
+
+      expect(result.resources).toEqual(['univ-a', 'univ-b'])
+      expect(result.total).toBe(2)
+    })
+  })
+
+  describe('login', () => {
+    const buildQuery = (overrides: Record<string, unknown> = {}) => ({ ticket: '', ...overrides } as never)
+    const buildReq = () =>
+      ({ get: jest.fn().mockReturnValue('app.test'), baseUrl: '', path: '/cas/login/my-cas' } as never)
+
+    it("devrait rejeter avec NotFoundResponse si le CAS n'existe pas", async () => {
+      service.findCasByName.mockResolvedValue(Optional.empty())
+
+      await expect(controller.login('unknown-cas', buildQuery(), buildReq())).rejects.toBeInstanceOf(NotFoundResponse)
+    })
+
+    it("devrait rediriger vers l'URL de connexion du CAS quand aucun ticket n'est fourni", async () => {
+      service.findCasByName.mockResolvedValue(Optional.of({ loginURL: 'https://cas.test/login' } as CasEntity))
+
+      const result = await controller.login('my-cas', buildQuery(), buildReq())
+
+      expect(result.statusCode).toBe(302)
+      expect(result.url).toContain('https://cas.test/login?service=')
+    })
+
+    it('devrait rediriger vers /login/no-account si le ticket CAS ne résout aucun utilisateur', async () => {
+      service.findCasByName.mockResolvedValue(
+        Optional.of({ serviceValidateURL: 'https://cas.test/validate', lmses: [] } as never)
+      )
+      jest.spyOn(controller, 'checkCasTicket').mockResolvedValue(Optional.empty())
+
+      const result = await controller.login('my-cas', buildQuery({ ticket: 'ST-1' }), buildReq())
+
+      expect(result).toEqual({ url: '/login/no-account', statusCode: 302 })
+    })
+
+    it('devrait rediriger vers /login/no-account si aucun utilisateur LMS ne correspond au username CAS', async () => {
+      service.findCasByName.mockResolvedValue(
+        Optional.of({ serviceValidateURL: 'https://cas.test/validate', lmses: [] } as never)
+      )
+      jest.spyOn(controller, 'checkCasTicket').mockResolvedValue(Optional.of('jdoe'))
+      ltiService.findLmsUserByUsername.mockResolvedValue(Optional.empty())
+
+      const result = await controller.login('my-cas', buildQuery({ ticket: 'ST-1' }), buildReq())
+
+      expect(result).toEqual({ url: '/login/no-account', statusCode: 302 })
+    })
+
+    it("devrait rediriger vers /login/no-account si l'utilisateur platon associé est introuvable", async () => {
+      service.findCasByName.mockResolvedValue(
+        Optional.of({ serviceValidateURL: 'https://cas.test/validate', lmses: [] } as never)
+      )
+      jest.spyOn(controller, 'checkCasTicket').mockResolvedValue(Optional.of('jdoe'))
+      ltiService.findLmsUserByUsername.mockResolvedValue(Optional.of({ userId: 'user-1' } as never))
+      userService.findById.mockResolvedValue(Optional.empty())
+
+      const result = await controller.login('my-cas', buildQuery({ ticket: 'ST-1' }), buildReq())
+
+      expect(result).toEqual({ url: '/login/no-account', statusCode: 302 })
+    })
+
+    it("devrait authentifier l'utilisateur et rediriger avec les tokens quand tout est résolu", async () => {
+      service.findCasByName.mockResolvedValue(
+        Optional.of({ serviceValidateURL: 'https://cas.test/validate', lmses: [] } as never)
+      )
+      jest.spyOn(controller, 'checkCasTicket').mockResolvedValue(Optional.of('jdoe'))
+      ltiService.findLmsUserByUsername.mockResolvedValue(Optional.of({ userId: 'user-1' } as never))
+      userService.findById.mockResolvedValue(Optional.of({ username: 'jdoe' } as never))
+      authService.authenticate.mockResolvedValue({ accessToken: 'access-1', refreshToken: 'refresh-1' })
+
+      const result = await controller.login('my-cas', buildQuery({ ticket: 'ST-1', next: '/home' }), buildReq())
+
+      expect(authService.authenticate).toHaveBeenCalledWith('user-1', 'jdoe')
+      expect(result.statusCode).toBe(302)
+      expect(result.url).toBe('/login?access-token=access-1&refresh-token=refresh-1&next=/home')
+    })
+  })
+
+  describe('searchCas / findCas / createCas / updateCas / deleteCas', () => {
+    it('searchCas devrait retourner les CAS mappés avec le total', async () => {
+      service.searchCas.mockResolvedValue([[{ id: 'cas-1' } as CasEntity], 1])
+
+      const result = await controller.searchCas({})
+
+      expect(result.total).toBe(1)
+    })
+
+    it("findCas devrait rejeter avec NotFoundResponse si le CAS n'existe pas", async () => {
+      service.findCasById.mockResolvedValue(Optional.empty())
+
+      await expect(controller.findCas('unknown')).rejects.toBeInstanceOf(NotFoundResponse)
+    })
+
+    it('findCas devrait retourner le CAS mappé', async () => {
+      service.findCasById.mockResolvedValue(Optional.of({ id: 'cas-1' } as CasEntity))
+
+      const result = await controller.findCas('cas-1')
+
+      expect(result.resource).toBeDefined()
+    })
+
+    it('createCas devrait construire le CAS via fromInput puis le créer', async () => {
+      service.fromInput.mockResolvedValue({ name: 'my-cas' } as never)
+      service.createCas.mockResolvedValue({ id: 'cas-1', name: 'my-cas' } as CasEntity)
+
+      const result = await controller.createCas({ name: 'my-cas' } as never)
+
+      expect(result.resource.name).toBe('my-cas')
+    })
+
+    it('updateCas devrait construire les changements via fromInput puis mettre à jour', async () => {
+      service.fromInput.mockResolvedValue({ name: 'Updated' } as never)
+      service.updateCas.mockResolvedValue({ id: 'cas-1', name: 'Updated' } as CasEntity)
+
+      const result = await controller.updateCas('cas-1', { name: 'Updated' } as never)
+
+      expect(service.updateCas).toHaveBeenCalledWith('cas-1', { name: 'Updated' })
+      expect(result.resource.name).toBe('Updated')
+    })
+
+    it('deleteCas devrait déléguer la suppression au service', async () => {
+      await controller.deleteCas('cas-1')
+
+      expect(service.deleteCas).toHaveBeenCalledWith('cas-1')
+    })
+  })
+})

--- a/libs/feature/cas/server/src/lib/cas.controller.ts
+++ b/libs/feature/cas/server/src/lib/cas.controller.ts
@@ -17,7 +17,6 @@ import { CasService } from './cas.service'
 import { CasDTO, CasFiltersDTO } from './cas.dto'
 import { CreatedResponse, ItemResponse, ListResponse, NoContentResponse, NotFoundResponse } from '@platon/core/common'
 import { Request } from 'express'
-import { of } from 'rxjs'
 import { CasServiceValidateResponse } from './payloads'
 import { AxiosError, AxiosResponse } from 'axios'
 import { Optional } from 'typescript-optional'
@@ -46,11 +45,11 @@ export class CasController {
         },
       })
       .catch((_error: AxiosError) => {
-        return of<CasServiceValidateResponse>({
+        return {
           serviceResponse: {
             authenticationFailure: { code: 'NO_RESPONSE', description: 'Your CAS provider is not accessible' },
           },
-        })
+        }
       })
 
     let response: CasServiceValidateResponse

--- a/libs/feature/cas/server/src/lib/cas.service.integration.spec.ts
+++ b/libs/feature/cas/server/src/lib/cas.service.integration.spec.ts
@@ -1,0 +1,188 @@
+import { CasVersions } from '@platon/feature/cas/common'
+import { LmsEntity, LTIService } from '@platon/feature/lti/server'
+import { createTestDatabase, TestDatabase } from '@platon/core/testing/server'
+import { DataSource, QueryFailedError, Repository } from 'typeorm'
+import { CasEntity } from './entities/cas.entity'
+import { CasService } from './cas.service'
+
+/**
+ * Contrairement à cas.service.spec.ts (repository/query builder mockés), ce fichier fait tourner
+ * CasService contre un vrai Postgres (Testcontainers) pour exercer les 3 contraintes uniques
+ * déclarées sur CasEntity (name, loginURL, serviceValidateURL) et la relation ManyToMany réelle
+ * avec LmsEntity (jointure lmses), qu'aucun mock de repository ne peut valider.
+ */
+describe('CasService (integration)', () => {
+  let testDb: TestDatabase
+  let dataSource: DataSource
+  let casRepo: Repository<CasEntity>
+  let lmsRepo: Repository<LmsEntity>
+  let service: CasService
+
+  const fakeLtiService = { findLmsById: jest.fn() } as unknown as LTIService
+
+  beforeAll(async () => {
+    testDb = await createTestDatabase([LmsEntity, CasEntity])
+    dataSource = testDb.dataSource
+    casRepo = dataSource.getRepository(CasEntity)
+    lmsRepo = dataSource.getRepository(LmsEntity)
+
+    service = new CasService(casRepo, fakeLtiService)
+  }, 60_000)
+
+  afterAll(async () => {
+    await testDb.teardown()
+  })
+
+  afterEach(async () => {
+    await dataSource.query('DELETE FROM "Cas"')
+    await dataSource.query('DELETE FROM "Lmses"')
+  })
+
+  let counter = 0
+  const seedCas = async (overrides: Partial<CasEntity> = {}): Promise<CasEntity> => {
+    counter++
+    return service.createCas({
+      name: `cas-${counter}`,
+      loginURL: `https://cas-${counter}.example.com/login`,
+      serviceValidateURL: `https://cas-${counter}.example.com/serviceValidate`,
+      version: CasVersions.V3,
+      ...overrides,
+    })
+  }
+
+  const seedLms = async (): Promise<LmsEntity> => {
+    counter++
+    return lmsRepo.save(
+      lmsRepo.create({
+        name: `Moodle ${counter}`,
+        url: 'https://moodle.example.com',
+        outcomeUrl: 'https://moodle.example.com/outcomes',
+        consumerKey: `consumer-key-${counter}`,
+        consumerSecret: 'secret',
+      })
+    )
+  }
+
+  describe('contraintes uniques', () => {
+    it('devrait rejeter deux CAS avec le même name', async () => {
+      await seedCas({ name: 'shared-name' })
+
+      await expect(seedCas({ name: 'shared-name' })).rejects.toBeInstanceOf(QueryFailedError)
+    })
+
+    it('devrait rejeter deux CAS avec la même loginURL', async () => {
+      await seedCas({ loginURL: 'https://shared.example.com/login' })
+
+      await expect(seedCas({ loginURL: 'https://shared.example.com/login' })).rejects.toBeInstanceOf(QueryFailedError)
+    })
+
+    it('devrait rejeter deux CAS avec la même serviceValidateURL', async () => {
+      await seedCas({ serviceValidateURL: 'https://shared.example.com/serviceValidate' })
+
+      await expect(
+        seedCas({ serviceValidateURL: 'https://shared.example.com/serviceValidate' })
+      ).rejects.toBeInstanceOf(QueryFailedError)
+    })
+  })
+
+  describe('relation ManyToMany avec les LMS', () => {
+    it('devrait persister et recharger les LMS associés à un CAS', async () => {
+      const lms1 = await seedLms()
+      const lms2 = await seedLms()
+      const cas = await seedCas({ lmses: [lms1, lms2] })
+
+      const found = await service.findCasByName(cas.name)
+
+      expect(found.isPresent()).toBe(true)
+      const lmsIds = found
+        .get()
+        .lmses.map((l) => l.id)
+        .sort()
+      expect(lmsIds).toEqual([lms1.id, lms2.id].sort())
+    })
+
+    it('devrait retourner un CAS sans LMS associé avec un tableau lmses vide', async () => {
+      const cas = await seedCas()
+
+      const found = await service.findCasByName(cas.name)
+
+      expect(found.get().lmses).toEqual([])
+    })
+  })
+
+  describe('searchCas', () => {
+    it('devrait filtrer par nom insensible à la casse et trier par nom', async () => {
+      await seedCas({ name: 'Alpha CAS' })
+      await seedCas({ name: 'Beta CAS' })
+
+      const [items, total] = await service.searchCas({ search: 'alpha' })
+
+      expect(total).toBe(1)
+      expect(items[0].name).toBe('Alpha CAS')
+    })
+
+    it('devrait paginer avec offset/limit sur le tri par défaut', async () => {
+      await seedCas({ name: 'A CAS' })
+      await seedCas({ name: 'B CAS' })
+      await seedCas({ name: 'C CAS' })
+
+      const [items, total] = await service.searchCas({ offset: 1, limit: 1 })
+
+      expect(total).toBe(3)
+      expect(items).toHaveLength(1)
+      expect(items[0].name).toBe('B CAS')
+    })
+
+    it('devrait trier explicitement par NAME/CREATED_AT/UPDATED_AT sans lever de colonne ambiguë avec la jointure lmses', async () => {
+      const lms = await seedLms()
+      await seedCas({ name: 'Z CAS', lmses: [lms] })
+      await seedCas({ name: 'A CAS', lmses: [lms] })
+
+      const byName = await service.searchCas({ order: 'NAME' as never })
+      expect(byName[0][0].name).toBe('A CAS')
+
+      await expect(service.searchCas({ order: 'CREATED_AT' as never })).resolves.toBeDefined()
+      await expect(service.searchCas({ order: 'UPDATED_AT' as never })).resolves.toBeDefined()
+    })
+
+    it('devrait filtrer par nom sans lever de colonne ambiguë quand un CAS a des LMS associés', async () => {
+      const lms = await seedLms()
+      await seedCas({ name: 'Alpha CAS', lmses: [lms] })
+
+      const [items, total] = await service.searchCas({ search: 'alpha' })
+
+      expect(total).toBe(1)
+      expect(items[0].name).toBe('Alpha CAS')
+    })
+  })
+
+  describe('updateCas', () => {
+    it('devrait fusionner les changements et sauvegarder', async () => {
+      const cas = await seedCas({ name: 'Old name' })
+
+      const updated = await service.updateCas(cas.id, { name: 'New name' })
+
+      expect(updated.name).toBe('New name')
+      const persisted = await casRepo.findOneBy({ id: cas.id })
+      expect(persisted?.name).toBe('New name')
+    })
+  })
+
+  describe('deleteCas / deleteCasByName', () => {
+    it('devrait supprimer un CAS par id', async () => {
+      const cas = await seedCas()
+
+      await service.deleteCas(cas.id)
+
+      expect(await casRepo.findOneBy({ id: cas.id })).toBeNull()
+    })
+
+    it('devrait supprimer un CAS par name', async () => {
+      const cas = await seedCas({ name: 'to-delete' })
+
+      await service.deleteCasByName('to-delete')
+
+      expect(await casRepo.findOneBy({ id: cas.id })).toBeNull()
+    })
+  })
+})

--- a/libs/feature/cas/server/src/lib/cas.service.spec.ts
+++ b/libs/feature/cas/server/src/lib/cas.service.spec.ts
@@ -86,7 +86,7 @@ describe('CasService', () => {
 
       await service.searchCas({ order: CasOrdering.CREATED_AT })
 
-      expect(qb.orderBy).toHaveBeenCalledWith('created_at', 'DESC')
+      expect(qb.orderBy).toHaveBeenCalledWith('cas.created_at', 'DESC')
     })
 
     it('devrait appliquer offset et limit', async () => {

--- a/libs/feature/cas/server/src/lib/cas.service.spec.ts
+++ b/libs/feature/cas/server/src/lib/cas.service.spec.ts
@@ -1,0 +1,191 @@
+import { Test, TestingModule } from '@nestjs/testing'
+import { getRepositoryToken } from '@nestjs/typeorm'
+import { NotFoundResponse } from '@platon/core/common'
+import { MockRepository, mockRepository, mockSelectQueryBuilder } from '@platon/core/testing/server'
+import { CasOrdering, CasVersions } from '@platon/feature/cas/common'
+import { LTIService } from '@platon/feature/lti/server'
+import { Optional } from 'typescript-optional'
+import { CasEntity } from './entities/cas.entity'
+import { CasService } from './cas.service'
+
+describe('CasService', () => {
+  let service: CasService
+  let repository: MockRepository<CasEntity>
+  let ltiService: jest.Mocked<LTIService>
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        CasService,
+        { provide: getRepositoryToken(CasEntity), useValue: mockRepository<CasEntity>() },
+        { provide: LTIService, useValue: { findLmsById: jest.fn() } },
+      ],
+    }).compile()
+
+    service = module.get(CasService)
+    repository = module.get(getRepositoryToken(CasEntity))
+    ltiService = module.get(LTIService)
+  })
+
+  describe('findCasById', () => {
+    it('devrait retourner Optional.of(cas) si trouvé', async () => {
+      const cas = { id: 'cas-1' } as CasEntity
+      repository.findOne.mockResolvedValue(cas)
+
+      const result = await service.findCasById('cas-1')
+
+      expect(result.get()).toBe(cas)
+    })
+
+    it('devrait retourner Optional.empty() si non trouvé', async () => {
+      repository.findOne.mockResolvedValue(null)
+
+      const result = await service.findCasById('unknown')
+
+      expect(result.isPresent()).toBe(false)
+    })
+  })
+
+  describe('findCasByName', () => {
+    it('devrait chercher par nom avec les LMS associés', async () => {
+      const qb = mockSelectQueryBuilder<CasEntity>()
+      const cas = { id: 'cas-1', name: 'my-cas' } as CasEntity
+      qb.getOne.mockResolvedValue(cas)
+      repository.createQueryBuilder.mockReturnValue(qb)
+
+      const result = await service.findCasByName('my-cas')
+
+      expect(qb.where).toHaveBeenCalledWith('cas.name = :name', { name: 'my-cas' })
+      expect(qb.leftJoinAndSelect).toHaveBeenCalledWith('cas.lmses', 'lmses')
+      expect(result.get()).toBe(cas)
+    })
+  })
+
+  describe('searchCas', () => {
+    it('devrait trier par nom ASC par défaut', async () => {
+      const qb = mockSelectQueryBuilder<CasEntity>()
+      repository.createQueryBuilder.mockReturnValue(qb)
+
+      await service.searchCas()
+
+      expect(qb.orderBy).toHaveBeenCalledWith('cas.name', 'ASC')
+    })
+
+    it('devrait filtrer par texte de recherche', async () => {
+      const qb = mockSelectQueryBuilder<CasEntity>()
+      repository.createQueryBuilder.mockReturnValue(qb)
+
+      await service.searchCas({ search: 'univ' })
+
+      expect(qb.andWhere).toHaveBeenCalledWith(expect.stringContaining('ILIKE'), { search: '%univ%' })
+    })
+
+    it('devrait trier selon order/direction fournis', async () => {
+      const qb = mockSelectQueryBuilder<CasEntity>()
+      repository.createQueryBuilder.mockReturnValue(qb)
+
+      await service.searchCas({ order: CasOrdering.CREATED_AT })
+
+      expect(qb.orderBy).toHaveBeenCalledWith('created_at', 'DESC')
+    })
+
+    it('devrait appliquer offset et limit', async () => {
+      const qb = mockSelectQueryBuilder<CasEntity>()
+      repository.createQueryBuilder.mockReturnValue(qb)
+
+      await service.searchCas({ offset: 5, limit: 10 })
+
+      expect(qb.offset).toHaveBeenCalledWith(5)
+      expect(qb.limit).toHaveBeenCalledWith(10)
+    })
+  })
+
+  describe('createCas', () => {
+    it('devrait sauvegarder le CAS', async () => {
+      const created = { id: 'cas-1' } as CasEntity
+      repository.save.mockResolvedValue(created)
+
+      const result = await service.createCas({ name: 'my-cas' })
+
+      expect(repository.save).toHaveBeenCalledWith({ name: 'my-cas' })
+      expect(result).toBe(created)
+    })
+  })
+
+  describe('updateCas', () => {
+    it("devrait rejeter avec NotFoundResponse si le CAS n'existe pas", async () => {
+      repository.findOne.mockResolvedValue(null)
+
+      await expect(service.updateCas('unknown', { name: 'New' })).rejects.toBeInstanceOf(NotFoundResponse)
+    })
+
+    it('devrait fusionner les changements et sauvegarder', async () => {
+      const cas = { id: 'cas-1', name: 'Old' } as CasEntity
+      repository.findOne.mockResolvedValue(cas)
+      repository.save.mockImplementation(async (c) => c as CasEntity)
+
+      const result = await service.updateCas('cas-1', { name: 'New' })
+
+      expect(result.name).toBe('New')
+    })
+  })
+
+  describe('deleteCas / deleteCasByName', () => {
+    it('devrait supprimer par id', async () => {
+      await service.deleteCas('cas-1')
+
+      expect(repository.delete).toHaveBeenCalledWith('cas-1')
+    })
+
+    it('devrait supprimer par nom', async () => {
+      await service.deleteCasByName('my-cas')
+
+      expect(repository.delete).toHaveBeenCalledWith({ name: 'my-cas' })
+    })
+  })
+
+  describe('fromInput', () => {
+    it('ne devrait pas toucher lmses si non fourni', async () => {
+      const result = await service.fromInput({
+        name: 'my-cas',
+        loginURL: 'https://cas.test/login',
+        serviceValidateURL: 'https://cas.test/validate',
+        version: CasVersions.V3,
+        lmses: [],
+      })
+
+      expect(result.lmses).toEqual([])
+      expect(ltiService.findLmsById).not.toHaveBeenCalled()
+    })
+
+    it('devrait résoudre les LMS fournis', async () => {
+      const lms = { id: 'lms-1' } as never
+      ltiService.findLmsById.mockResolvedValue(Optional.of(lms))
+
+      const result = await service.fromInput({
+        name: 'my-cas',
+        loginURL: 'https://cas.test/login',
+        serviceValidateURL: 'https://cas.test/validate',
+        version: CasVersions.V3,
+        lmses: ['lms-1'],
+      })
+
+      expect(ltiService.findLmsById).toHaveBeenCalledWith('lms-1')
+      expect(result.lmses).toEqual([lms])
+    })
+
+    it("devrait rejeter avec NotFoundResponse si un LMS fourni n'existe pas", async () => {
+      ltiService.findLmsById.mockResolvedValue(Optional.empty())
+
+      await expect(
+        service.fromInput({
+          name: 'my-cas',
+          loginURL: 'https://cas.test/login',
+          serviceValidateURL: 'https://cas.test/validate',
+          version: CasVersions.V3,
+          lmses: ['unknown'],
+        })
+      ).rejects.toBeInstanceOf(NotFoundResponse)
+    })
+  })
+})

--- a/libs/feature/cas/server/src/lib/cas.service.ts
+++ b/libs/feature/cas/server/src/lib/cas.service.ts
@@ -37,7 +37,7 @@ export class CasService {
     if (filters.search) {
       query.andWhere(
         `(
-        name ILIKE :search
+        cas.name ILIKE :search
       )`,
         { search: `%${filters.search}%` }
       )
@@ -45,9 +45,9 @@ export class CasService {
 
     if (filters.order) {
       const fields: Record<CasOrdering, string> = {
-        NAME: 'name',
-        CREATED_AT: 'created_at',
-        UPDATED_AT: 'updated_at',
+        NAME: 'cas.name',
+        CREATED_AT: 'cas.created_at',
+        UPDATED_AT: 'cas.updated_at',
       }
 
       const orderings: Record<CasOrdering, keyof typeof OrderingDirections> = {

--- a/libs/feature/cas/server/tsconfig.integration.json
+++ b/libs/feature/cas/server/tsconfig.integration.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "module": "commonjs",
+    "target": "es2018",
+    "types": ["jest", "node"],
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true
+  },
+  "include": ["jest.integration.config.ts", "src/**/*.integration.spec.ts", "src/**/*.d.ts"]
+}

--- a/libs/feature/webcomponent/src/lib/forms/math-live/math-live.component.ts
+++ b/libs/feature/webcomponent/src/lib/forms/math-live/math-live.component.ts
@@ -44,8 +44,7 @@ export class MathLiveComponent implements OnInit, WebComponentHooks<MathLiveStat
 
   displayMenu = true
   computeEngine = new ComputeEngine()
-
-  async ngOnInit() {
+    async ngOnInit() {
     this.state.isFilled = false
     this.mathfield = new MathfieldElement()
     this.mathfield.value = this.state.value
@@ -56,13 +55,13 @@ export class MathLiveComponent implements OnInit, WebComponentHooks<MathLiveStat
     this.mathfield.oninput = () => {
       this.changeDetection
         .ignore(this, () => {
-          this.state.value = this.computeEngine
-            .parse(this.mathfield.getValue('latex-expanded'), {
-              canonical: false,
-            })
-            .toLatex({
-              invisiblePlus: '+',
-            })
+          const rawLatex = this.mathfield.getValue('latex-expanded')
+          const expr = this.computeEngine.parse(rawLatex, {
+            canonical: false,
+          })
+          this.state.value = expr.isValid
+            ? expr.toLatex({ invisiblePlus: '+', prettify: false })
+            : rawLatex
           this.state.isFilled = true
         })
         .catch(console.error)

--- a/libs/feature/webcomponent/src/lib/forms/math-live/math-live.component.ts
+++ b/libs/feature/webcomponent/src/lib/forms/math-live/math-live.component.ts
@@ -44,7 +44,7 @@ export class MathLiveComponent implements OnInit, WebComponentHooks<MathLiveStat
 
   displayMenu = true
   computeEngine = new ComputeEngine()
-    async ngOnInit() {
+  async ngOnInit() {
     this.state.isFilled = false
     this.mathfield = new MathfieldElement()
     this.mathfield.value = this.state.value
@@ -59,9 +59,7 @@ export class MathLiveComponent implements OnInit, WebComponentHooks<MathLiveStat
           const expr = this.computeEngine.parse(rawLatex, {
             canonical: false,
           })
-          this.state.value = expr.isValid
-            ? expr.toLatex({ invisiblePlus: '+', prettify: false })
-            : rawLatex
+          this.state.value = expr.isValid ? expr.toLatex({ invisiblePlus: '+', prettify: false }) : rawLatex
           this.state.isFilled = true
         })
         .catch(console.error)


### PR DESCRIPTION
This pull request introduces significant improvements to the CAS (Central Authentication Service) server feature, focusing on enhanced test coverage, improved test configuration, and minor bug fixes in the web editor. The main changes include adding comprehensive unit and integration tests for the CAS server, updating Jest configuration for better test separation, and fixing object mutation issues in the PLA editor.

**Testing improvements:**

* Added a new Jest integration test configuration (`jest.integration.config.ts`) for the CAS server, and new Nx targets to run both unit and integration tests separately or together. This ensures unique constraints and entity relationships are tested against a real database. [[1]](diffhunk://#diff-60e6cd00751648a72ad0a0ec460d85f579050be9fb56829d42b364107a7dcff2R1-R18) [[2]](diffhunk://#diff-9dbe48aa56ed5059e974c4d858eb4ea440fe5db8ff7ec7b3cba1c4c505eebef5R28-R42)
* Added extensive integration tests for `CasService` to verify unique constraints and ManyToMany relationships with LMS entities using a real Postgres database.
* Added a complete unit test suite for `CasController`, covering CAS ticket validation, login flows, and CRUD operations.
* Added a unit test for `AxiosService` to verify proxy configuration logic and response handling.

**Test configuration and minor fixes:**

* Updated the main Jest config to ignore integration and e2e tests, ensuring only unit tests run by default.
* Fixed a minor bug in the PLA editor by ensuring that the default grader object is cloned instead of being assigned by reference, preventing unintended mutations. [[1]](diffhunk://#diff-e76c68abee8bd4f7dd64745b250cb7c3ed8064d7dfc0268f84ba80146f9dfb88L358-R358) [[2]](diffhunk://#diff-e76c68abee8bd4f7dd64745b250cb7c3ed8064d7dfc0268f84ba80146f9dfb88L557-R557) [[3]](diffhunk://#diff-e76c68abee8bd4f7dd64745b250cb7c3ed8064d7dfc0268f84ba80146f9dfb88L836-R836)
* Simplified error handling in `CasController` by removing unnecessary RxJS usage for error responses. [[1]](diffhunk://#diff-845867f48901906ceb70447e7a004ae3ff2b3a272339ed8ceb1b70cb182d07f3L20) [[2]](diffhunk://#diff-845867f48901906ceb70447e7a004ae3ff2b3a272339ed8ceb1b70cb182d07f3L49-R52)