### PR TITLE
Test/coverage notification server

### DIFF
--- a/libs/feature/notification/server/jest.config.ts
+++ b/libs/feature/notification/server/jest.config.ts
@@ -1,6 +1,7 @@
 module.exports = {
   displayName: 'feature-notification-server',
   preset: '../../../../jest.preset.js',
+  testPathIgnorePatterns: ['/node_modules/', '\\.integration\\.spec\\.ts$', '\\.e2e\\.spec\\.ts$'],
   testEnvironment: 'node',
   transform: {
     '^.+\\.ts$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.spec.json' }],

--- a/libs/feature/notification/server/jest.integration.config.ts
+++ b/libs/feature/notification/server/jest.integration.config.ts
@@ -1,0 +1,18 @@
+export default {
+  displayName: 'feature-notification-server-integration',
+  preset: '../../../../jest.preset.js',
+  testMatch: ['**/*.integration.spec.ts'],
+  testTimeout: 60_000,
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.ts$': ['ts-jest', { tsconfig: '<rootDir>/tsconfig.integration.json' }],
+    '^.+\\.js$': [
+      '@swc/jest',
+      {
+        jsc: { target: 'es2022', parser: { syntax: 'ecmascript' } },
+        module: { type: 'commonjs' },
+      },
+    ],
+  },
+  coverageDirectory: '../../../../coverage/libs/feature/notification/server/integration',
+}

--- a/libs/feature/notification/server/project.json
+++ b/libs/feature/notification/server/project.json
@@ -14,6 +14,21 @@
       "options": {
         "jestConfig": "libs/feature/notification/server/jest.config.ts"
       }
+    },
+    "test:integration": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}/integration"],
+      "options": {
+        "jestConfig": "libs/feature/notification/server/jest.integration.config.ts",
+        "passWithNoTests": false
+      }
+    },
+    "test:all": {
+      "executor": "nx:run-commands",
+      "options": {
+        "commands": ["nx run feature-notification-server:test", "nx run feature-notification-server:test:integration"],
+        "parallel": false
+      }
     }
   }
 }

--- a/libs/feature/notification/server/src/lib/notification.service.integration.spec.ts
+++ b/libs/feature/notification/server/src/lib/notification.service.integration.spec.ts
@@ -1,0 +1,137 @@
+import { DiscoveryService } from '@golevelup/nestjs-discovery'
+import { UserRoles } from '@platon/core/common'
+import { PubSubService, UserEntity } from '@platon/core/server'
+import { createTestDatabase, TestDatabase } from '@platon/core/testing/server'
+import { DataSource, Repository } from 'typeorm'
+import { NotificationEntity } from './notification.entity'
+import { NotificationService } from './notification.service'
+
+/**
+ * Contrairement à notification.service.spec.ts (repository/query builder mockés), ce fichier fait
+ * tourner NotificationService contre un vrai Postgres (Testcontainers) pour exercer :
+ * - la cascade DB réelle (onDelete: 'CASCADE' sur NotificationEntity.user), invisible à un mock
+ *   de repository qui ne supprime jamais réellement de lignes liées ;
+ * - deleteWhere() avec une vraie expression de query builder chaînée (buildDeleteQuery), plutôt
+ *   qu'un mock de delete()/from()/where() qui ne vérifie jamais que le SQL généré est valide ;
+ * - ofUser() avec un vrai tri/pagination/filtre sur une vraie table.
+ */
+describe('NotificationService (integration)', () => {
+  let testDb: TestDatabase
+  let dataSource: DataSource
+  let userRepo: Repository<UserEntity>
+  let notificationRepo: Repository<NotificationEntity>
+  let service: NotificationService
+
+  const discovery = { providersWithMetaAtKey: jest.fn().mockResolvedValue([]) } as unknown as DiscoveryService
+
+  beforeAll(async () => {
+    testDb = await createTestDatabase([UserEntity, NotificationEntity])
+    dataSource = testDb.dataSource
+    userRepo = dataSource.getRepository(UserEntity)
+    notificationRepo = dataSource.getRepository(NotificationEntity)
+
+    // Le pubsub ne fait pas partie de ce qu'on veut valider ici (DB réelle) ; PubSub réel exige
+    // Redis, donc on garde un simple stub côté publish comme dans les specs unitaires.
+    const pubSubService = { publish: jest.fn().mockResolvedValue(undefined) } as unknown as PubSubService
+    service = new NotificationService(notificationRepo, discovery, pubSubService)
+  }, 60_000)
+
+  afterAll(async () => {
+    await testDb.teardown()
+  })
+
+  afterEach(async () => {
+    await dataSource.query('TRUNCATE "Notifications" CASCADE')
+    await dataSource.query('TRUNCATE "Users" CASCADE')
+  })
+
+  let userCounter = 0
+  const seedUser = async (): Promise<UserEntity> => {
+    userCounter++
+    return userRepo.save(
+      userRepo.create({
+        username: `notif-integration-user-${userCounter}`,
+        firstName: 'Test',
+        lastName: 'User',
+        email: `notif-integration-user-${userCounter}@test.local`,
+        role: UserRoles.student,
+        active: true,
+        lastActivity: new Date(),
+      })
+    )
+  }
+
+  describe('cascade DB', () => {
+    it("devrait supprimer automatiquement les notifications d'un utilisateur supprimé", async () => {
+      const user = await seedUser()
+      await service.sendToUser(user.id, { type: 'FOO' })
+
+      await userRepo.delete(user.id)
+
+      const remaining = await notificationRepo.find({ where: { userId: user.id } })
+      expect(remaining).toHaveLength(0)
+    })
+  })
+
+  describe('deleteWhere', () => {
+    it('devrait supprimer uniquement les notifications correspondant à une expression additionnelle réelle', async () => {
+      const user = await seedUser()
+      await service.sendToUser(user.id, { type: 'FOO' })
+      await service.sendToUser(user.id, { type: 'BAR' })
+
+      const affected = await service.deleteWhere(user.id, (qb) => qb.andWhere(`data->>'type' = :type`, { type: 'FOO' }))
+
+      expect(affected).toBe(1)
+      const remaining = await notificationRepo.find({ where: { userId: user.id } })
+      expect(remaining).toHaveLength(1)
+      expect(remaining[0].data['type']).toBe('BAR')
+    })
+
+    it("ne devrait pas supprimer les notifications d'un autre utilisateur", async () => {
+      const user1 = await seedUser()
+      const user2 = await seedUser()
+      await service.sendToUser(user1.id, { type: 'FOO' })
+      await service.sendToUser(user2.id, { type: 'FOO' })
+
+      await service.deleteWhere(user1.id)
+
+      expect(await notificationRepo.find({ where: { userId: user1.id } })).toHaveLength(0)
+      expect(await notificationRepo.find({ where: { userId: user2.id } })).toHaveLength(1)
+    })
+  })
+
+  describe('ofUser', () => {
+    it('devrait trier par date décroissante, filtrer les non lues et paginer', async () => {
+      const user = await seedUser()
+      const n1 = await service.sendToUser(user.id, { type: 'FIRST' })
+      await new Promise((resolve) => setTimeout(resolve, 5))
+      const n2 = await service.sendToUser(user.id, { type: 'SECOND' })
+      await notificationRepo.update(n1.id, { readAt: new Date() })
+
+      const [unread] = await service.ofUser(user.id, { unread: true })
+      expect(unread.map((n) => n.id)).toEqual([n2.id])
+
+      const [all] = await service.ofUser(user.id)
+      expect(all.map((n) => n.id)).toEqual([n2.id, n1.id])
+
+      const [paged] = await service.ofUser(user.id, { offset: 1, limit: 1 })
+      expect(paged.map((n) => n.id)).toEqual([n1.id])
+    })
+  })
+
+  describe('markAsRead / markAllAsRead / unreadCount', () => {
+    it('devrait marquer une notification comme lue puis refléter le compteur', async () => {
+      const user = await seedUser()
+      const n1 = await service.sendToUser(user.id, { type: 'FOO' })
+      await service.sendToUser(user.id, { type: 'BAR' })
+
+      expect(await service.unreadCount(user.id)).toBe(2)
+
+      await service.markAsRead(user.id, [n1.id])
+      expect(await service.unreadCount(user.id)).toBe(1)
+
+      await service.markAllAsRead(user.id)
+      expect(await service.unreadCount(user.id)).toBe(0)
+    })
+  })
+})

--- a/libs/feature/notification/server/tsconfig.integration.json
+++ b/libs/feature/notification/server/tsconfig.integration.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "module": "commonjs",
+    "target": "es2018",
+    "types": ["jest", "node"],
+    "emitDecoratorMetadata": true,
+    "experimentalDecorators": true
+  },
+  "include": ["jest.integration.config.ts", "src/**/*.integration.spec.ts", "src/**/*.d.ts"]
+}


### PR DESCRIPTION
This pull request introduces integration testing support for the `feature-notification-server` library. It adds configuration, scripts, and a comprehensive integration test suite to validate the notification service against a real PostgreSQL database, ensuring correct behavior for database cascades, query logic, and user notification flows.

**Integration testing infrastructure:**

* Added `jest.integration.config.ts` to configure Jest for running integration tests, including test matching, environment, and coverage output.
* Created `tsconfig.integration.json` to provide TypeScript settings for integration tests.
* Updated `jest.config.ts` to exclude integration and e2e tests from the default test run.

**Nx project configuration:**

* Updated `project.json` to add `test:integration` and `test:all` targets, enabling separate and combined runs of unit and integration tests.

**Integration test suite:**

* Added `notification.service.integration.spec.ts`, a thorough test suite that exercises the notification service against a real database, verifying cascade deletes, query builder logic, sorting, pagination, and read/unread flows.